### PR TITLE
LineAfter sniff - fixed case when next content is doc-block

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Methods/LineAfterSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Methods/LineAfterSniff.php
@@ -10,10 +10,18 @@ use PHP_CodeSniffer\Util\Tokens;
 
 use function in_array;
 use function max;
+use function strpos;
 
 use const T_ANON_CLASS;
 use const T_CLASS;
 use const T_CLOSE_CURLY_BRACKET;
+use const T_DOC_COMMENT;
+use const T_DOC_COMMENT_CLOSE_TAG;
+use const T_DOC_COMMENT_OPEN_TAG;
+use const T_DOC_COMMENT_STAR;
+use const T_DOC_COMMENT_STRING;
+use const T_DOC_COMMENT_TAG;
+use const T_DOC_COMMENT_WHITESPACE;
 use const T_FUNCTION;
 use const T_INTERFACE;
 use const T_SEMICOLON;
@@ -42,9 +50,20 @@ class LineAfterSniff extends AbstractScopeSniff
             $closer = $phpcsFile->findNext(T_SEMICOLON, $tokens[$stackPtr]['parenthesis_closer'] + 1);
         }
 
+        $emptyTokens = Tokens::$emptyTokens;
+        unset(
+            $emptyTokens[T_DOC_COMMENT],
+            $emptyTokens[T_DOC_COMMENT_STAR],
+            $emptyTokens[T_DOC_COMMENT_WHITESPACE],
+            $emptyTokens[T_DOC_COMMENT_TAG],
+            $emptyTokens[T_DOC_COMMENT_OPEN_TAG],
+            $emptyTokens[T_DOC_COMMENT_CLOSE_TAG],
+            $emptyTokens[T_DOC_COMMENT_STRING]
+        );
+
         $lastInLine = $closer;
         while ($tokens[$lastInLine + 1]['line'] === $tokens[$closer]['line']
-            && in_array($tokens[$lastInLine + 1]['code'], Tokens::$emptyTokens, true)
+            && in_array($tokens[$lastInLine + 1]['code'], $emptyTokens, true)
         ) {
             ++$lastInLine;
         }
@@ -52,7 +71,12 @@ class LineAfterSniff extends AbstractScopeSniff
             --$lastInLine;
         }
 
-        $contentAfter = $phpcsFile->findNext(T_WHITESPACE, $lastInLine + 1, null, true);
+        if ($tokens[$lastInLine]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+            $contentAfter = $lastInLine;
+        } else {
+            $contentAfter = $phpcsFile->findNext(T_WHITESPACE, $lastInLine + 1, null, true);
+        }
+
         if ($contentAfter !== false
             && $tokens[$contentAfter]['line'] - $tokens[$closer]['line'] !== 2
             && $tokens[$contentAfter]['code'] !== T_CLOSE_CURLY_BRACKET
@@ -64,8 +88,18 @@ class LineAfterSniff extends AbstractScopeSniff
 
             if ($fix) {
                 if ($found) {
+                    $skip = 2;
+
                     $phpcsFile->fixer->beginChangeset();
-                    for ($i = $closer + 1; $i < $contentAfter - 1; $i++) {
+                    for ($i = $contentAfter - 1; $i > $closer; --$i) {
+                        if ($skip) {
+                            if (strpos($tokens[$i]['content'], $phpcsFile->eolChar) !== false) {
+                                --$skip;
+                            }
+
+                            continue;
+                        }
+
                         $phpcsFile->fixer->replaceToken($i, '');
                     }
                     $phpcsFile->fixer->endChangeset();

--- a/src/WebimpressCodingStandard/Sniffs/Methods/LineAfterSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Methods/LineAfterSniff.php
@@ -71,12 +71,7 @@ class LineAfterSniff extends AbstractScopeSniff
             --$lastInLine;
         }
 
-        if ($tokens[$lastInLine]['code'] === T_DOC_COMMENT_OPEN_TAG) {
-            $contentAfter = $lastInLine;
-        } else {
-            $contentAfter = $phpcsFile->findNext(T_WHITESPACE, $lastInLine + 1, null, true);
-        }
-
+        $contentAfter = $phpcsFile->findNext(T_WHITESPACE, $lastInLine + 1, null, true);
         if ($contentAfter !== false
             && $tokens[$contentAfter]['line'] - $tokens[$closer]['line'] !== 2
             && $tokens[$contentAfter]['code'] !== T_CLOSE_CURLY_BRACKET

--- a/test/Sniffs/Methods/LineAfterUnitTest.inc
+++ b/test/Sniffs/Methods/LineAfterUnitTest.inc
@@ -32,4 +32,23 @@ abstract class LineAfter
     } /* another comment */public function inTheSameLine()
     {
     } # comment
+
+    public function nextWithDocBlock()
+    {
+    }
+
+
+    /**
+     * @return int
+     */
+    public function returnInt()
+    {
+        return 0;
+    }/**
+     * @return string
+     */
+    public function returnString()
+    {
+        return '';
+    }
 }

--- a/test/Sniffs/Methods/LineAfterUnitTest.inc.fixed
+++ b/test/Sniffs/Methods/LineAfterUnitTest.inc.fixed
@@ -39,4 +39,24 @@ private function method7(){}
 public function inTheSameLine()
     {
     } # comment
+
+    public function nextWithDocBlock()
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function returnInt()
+    {
+        return 0;
+    }
+
+/**
+     * @return string
+     */
+    public function returnString()
+    {
+        return '';
+    }
 }

--- a/test/Sniffs/Methods/LineAfterUnitTest.php
+++ b/test/Sniffs/Methods/LineAfterUnitTest.php
@@ -50,6 +50,8 @@ class LineAfterUnitTest extends AbstractTestCase
             24 => 1,
             29 => 1,
             32 => 1,
+            38 => 1,
+            47 => 1,
         ];
     }
 


### PR DESCRIPTION
Fixed adding empty line after method when the next content is doc-block.
Improvements in the sniffs to fix quicker.