### PR TITLE
Comment Placement sniff - allow comments in the first column after PHP opening tag

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Commenting/PlacementSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/PlacementSniff.php
@@ -30,7 +30,8 @@ class PlacementSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        if ($tokens[$stackPtr - 1]['code'] !== T_WHITESPACE
+        if ($tokens[$stackPtr]['column'] !== 1
+            && $tokens[$stackPtr - 1]['code'] !== T_WHITESPACE
             && ($tokens[$stackPtr - 1]['code'] !== T_COMMENT
                 || $tokens[$stackPtr - 1]['line'] === $tokens[$stackPtr]['line'])
         ) {

--- a/test/Sniffs/Commenting/PlacementUnitTest.inc
+++ b/test/Sniffs/Commenting/PlacementUnitTest.inc
@@ -1,4 +1,5 @@
 <?php
+/* comment */
 
 echo /* 1 */ 'hey';
 echo 'world';// hey

--- a/test/Sniffs/Commenting/PlacementUnitTest.inc.fixed
+++ b/test/Sniffs/Commenting/PlacementUnitTest.inc.fixed
@@ -1,4 +1,5 @@
 <?php
+/* comment */
 
 echo   'hey'; /* 1 */
 echo 'world'; // hey

--- a/test/Sniffs/Commenting/PlacementUnitTest.php
+++ b/test/Sniffs/Commenting/PlacementUnitTest.php
@@ -11,10 +11,10 @@ class PlacementUnitTest extends AbstractTestCase
     protected function getErrorList(string $testFile = '') : array
     {
         return [
-            3 => 1,
             4 => 1,
-            6 => 3,
-            8 => 3,
+            5 => 1,
+            7 => 3,
+            9 => 3,
         ];
     }
 


### PR DESCRIPTION
Fixed false positive when space was required before comment which was after php open tag.