### PR TITLE
DocComment sniff - do not require blank line before doc comment when in array or function call

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/DocCommentSniff.php
@@ -31,6 +31,8 @@ use const T_DOC_COMMENT_TAG;
 use const T_DOC_COMMENT_WHITESPACE;
 use const T_NAMESPACE;
 use const T_OPEN_CURLY_BRACKET;
+use const T_OPEN_PARENTHESIS;
+use const T_OPEN_SHORT_ARRAY;
 use const T_OPEN_TAG;
 use const T_USE;
 use const T_WHITESPACE;
@@ -182,8 +184,12 @@ class DocCommentSniff implements Sniff
                 $phpcsFile->fixer->endChangeset();
             }
         } elseif ($tokens[$previous]['line'] === $tokens[$commentStart]['line'] - 1
-            && $tokens[$previous]['code'] !== T_OPEN_TAG
-            && $tokens[$previous]['code'] !== T_OPEN_CURLY_BRACKET
+            && ! in_array($tokens[$previous]['code'], [
+                T_OPEN_CURLY_BRACKET,
+                T_OPEN_PARENTHESIS,
+                T_OPEN_SHORT_ARRAY,
+                T_OPEN_TAG,
+            ], true)
         ) {
             $error = 'Missing blank line before doc comment';
             $fix = $phpcsFile->addFixableError($error, $commentStart, 'MissingBlankLine');

--- a/test/Sniffs/Commenting/DocCommentUnitTest.inc
+++ b/test/Sniffs/Commenting/DocCommentUnitTest.inc
@@ -260,4 +260,30 @@ class Foo
      *           bar baz
      */
     public function descriptionIndentWithTags() {}
+
+    public function docCommentInArray() : array
+    {
+        return [
+            /**
+             * @param mixed $a
+             * @return mixed
+             */
+            static function ($a) {
+                return $a;
+            },
+        ];
+    }
+
+    public function docCommentInFunctionCall() : callable
+    {
+        $this->getName(
+            /**
+             * @param mixed $a
+             * @return mixed
+             */
+            static function ($a) {
+                return $a;
+            }
+        );
+    }
 }

--- a/test/Sniffs/Commenting/DocCommentUnitTest.inc.fixed
+++ b/test/Sniffs/Commenting/DocCommentUnitTest.inc.fixed
@@ -262,4 +262,30 @@ $c = 'xyz';
      *     bar baz
      */
     public function descriptionIndentWithTags() {}
+
+    public function docCommentInArray() : array
+    {
+        return [
+            /**
+             * @param mixed $a
+             * @return mixed
+             */
+            static function ($a) {
+                return $a;
+            },
+        ];
+    }
+
+    public function docCommentInFunctionCall() : callable
+    {
+        $this->getName(
+            /**
+             * @param mixed $a
+             * @return mixed
+             */
+            static function ($a) {
+                return $a;
+            }
+        );
+    }
 }


### PR DESCRIPTION
Blank line shouldn't be required before doc-block in array (when on the top) or when in function call. See test for more details.