### PR TITLE
StringClassReference sniff - better detection possible string classes

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Formatting/StringClassReferenceSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Formatting/StringClassReferenceSniff.php
@@ -13,6 +13,7 @@ use function ltrim;
 use function preg_match;
 use function strpos;
 use function strtr;
+use function substr;
 use function trait_exists;
 
 use const T_CONSTANT_ENCAPSED_STRING;
@@ -44,7 +45,9 @@ class StringClassReferenceSniff implements Sniff
         ]);
 
         if (strpos($name, '\\\\') !== false
-            || preg_match('/\s/', $name)
+            || preg_match('/[^\\a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]/', $name)
+            || substr($name, -1) === '\\'
+            || ltrim($name, '\\') === ''
         ) {
             return;
         }

--- a/src/WebimpressCodingStandard/Sniffs/Formatting/StringClassReferenceSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Formatting/StringClassReferenceSniff.php
@@ -10,10 +10,10 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use function class_exists;
 use function interface_exists;
 use function ltrim;
-use function str_replace;
+use function preg_match;
 use function strpos;
+use function strtr;
 use function trait_exists;
-use function trim;
 
 use const T_CONSTANT_ENCAPSED_STRING;
 
@@ -37,7 +37,18 @@ class StringClassReferenceSniff implements Sniff
             return;
         }
 
-        $name = trim(str_replace(['"', "'"], '', $tokens[$stackPtr]['content']));
+        $name = strtr($tokens[$stackPtr]['content'], [
+            '"' => '',
+            "'" => '',
+            '\\\\' => '\\',
+        ]);
+
+        if (strpos($name, '\\\\') !== false
+            || preg_match('/\s/', $name)
+        ) {
+            return;
+        }
+
         if (class_exists($name) || interface_exists($name) || trait_exists($name)) {
             $error = 'String "%s" contains class reference, use ::class instead';
             $data = [$name];

--- a/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc
+++ b/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc
@@ -20,3 +20,6 @@ $newLineInTheName = 'WebimpressCodingStandardTest
 
 $spaceAtTheBeginning = ' WebimpressCodingStandardTest\\Ruleset';
 $spaceAtTheEnd = ' WebimpressCodingStandardTest\\Ruleset ';
+
+$namespaceSeparatorAtTheEnd = 'WebimpressCodingStandardTest\\Ruleset\\';
+$justNamespaceSeparator = '\\';

--- a/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc
+++ b/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc
@@ -11,3 +11,12 @@ $trait = 'WebimpressCodingStandard\Helper\NamespacesTrait';
 
 $nonExistingClass = 'MyNamespace\ClassDoesNotExist';
 $nonSlash = 'DateTime';
+
+$doubleNamespaceSeparator = 'WebimpressCodingStandardTest\\Ruleset';
+$fourBackslashes = 'WebimpressCodingStandardTest\\\\Ruleset';
+$spaceInTheName = 'WebimpressCodingStandardTest Ruleset';
+$newLineInTheName = 'WebimpressCodingStandardTest
+    Ruleset';
+
+$spaceAtTheBeginning = ' WebimpressCodingStandardTest\\Ruleset';
+$spaceAtTheEnd = ' WebimpressCodingStandardTest\\Ruleset ';

--- a/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc.fixed
+++ b/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc.fixed
@@ -20,3 +20,6 @@ $newLineInTheName = 'WebimpressCodingStandardTest
 
 $spaceAtTheBeginning = ' WebimpressCodingStandardTest\\Ruleset';
 $spaceAtTheEnd = ' WebimpressCodingStandardTest\\Ruleset ';
+
+$namespaceSeparatorAtTheEnd = 'WebimpressCodingStandardTest\\Ruleset\\';
+$justNamespaceSeparator = '\\';

--- a/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc.fixed
+++ b/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc.fixed
@@ -11,3 +11,12 @@ $trait = \WebimpressCodingStandard\Helper\NamespacesTrait::class;
 
 $nonExistingClass = 'MyNamespace\ClassDoesNotExist';
 $nonSlash = 'DateTime';
+
+$doubleNamespaceSeparator = \WebimpressCodingStandardTest\Ruleset::class;
+$fourBackslashes = 'WebimpressCodingStandardTest\\\\Ruleset';
+$spaceInTheName = 'WebimpressCodingStandardTest Ruleset';
+$newLineInTheName = 'WebimpressCodingStandardTest
+    Ruleset';
+
+$spaceAtTheBeginning = ' WebimpressCodingStandardTest\\Ruleset';
+$spaceAtTheEnd = ' WebimpressCodingStandardTest\\Ruleset ';

--- a/test/Sniffs/Formatting/StringClassReferenceUnitTest.php
+++ b/test/Sniffs/Formatting/StringClassReferenceUnitTest.php
@@ -16,6 +16,7 @@ class StringClassReferenceUnitTest extends AbstractTestCase
             7 => 1,
             8 => 1,
             10 => 1,
+            15 => 1,
         ];
     }
 


### PR DESCRIPTION
In PHP string backslash can be escaped. Tokenizer returns content with escape character so we need to replace drop these escape characters.

We can also return early when name contains spaces as it cannot be a valid class name.