### PR TITLE
RedundantParentheses sniff - false-positive when class invoked in statement

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Formatting/RedundantParenthesesSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Formatting/RedundantParenthesesSniff.php
@@ -170,6 +170,11 @@ class RedundantParenthesesSniff implements Sniff
             return;
         }
 
+        // Skip when open parenthesis after closing parenthesis
+        if ($tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
+            return;
+        }
+
         // Check single expression casting
         if (in_array($tokens[$prev]['code'], Tokens::$castTokens, true)) {
             $op = $phpcsFile->findNext(

--- a/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc
+++ b/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc
@@ -186,4 +186,10 @@ class RedundantParentheses
             echo 1;
         }
     }
+
+    public function method12()
+    {
+        if (! (new Invoke())()) {}
+        if (! (new Invoke())->method()) {}
+    }
 }

--- a/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc.fixed
+++ b/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc.fixed
@@ -186,4 +186,10 @@ class RedundantParentheses
             echo 1;
         }
     }
+
+    public function method12()
+    {
+        if (! (new Invoke())()) {}
+        if (! (new Invoke())->method()) {}
+    }
 }


### PR DESCRIPTION
Fixes false-positive when class invoked with negation

/cc @weierophinney