### PR TITLE
UnusedUseStatement sniff - better recognise classes in doc-block annotations

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
@@ -125,6 +125,8 @@ class UnusedUseStatementSniff implements Sniff
         while ($classUsed !== false) {
             $isStringToken = $tokens[$classUsed]['code'] === T_STRING;
 
+            $match = null;
+
             if (($isStringToken && strtolower($tokens[$classUsed]['content']) === $lowerClassName)
                 || ($tokens[$classUsed]['code'] === T_DOC_COMMENT_STRING
                     && preg_match(
@@ -135,6 +137,16 @@ class UnusedUseStatementSniff implements Sniff
                     && preg_match(
                         '/@' . preg_quote($lowerClassName, '/') . '(\(|\\\\|$)/i',
                         $tokens[$classUsed]['content']
+                    ))
+                || (! $isStringToken
+                    && ! preg_match(
+                        '/"[^"]*' . preg_quote($lowerClassName, '/') . '\b[^"]*"/i',
+                        $tokens[$classUsed]['content']
+                    )
+                    && preg_match(
+                        '/(?<!")@' . preg_quote($lowerClassName, '/') . '\b/i',
+                        $tokens[$classUsed]['content'],
+                        $match
                     ))
             ) {
                 $beforeUsage = $phpcsFile->findPrevious(
@@ -165,6 +177,10 @@ class UnusedUseStatementSniff implements Sniff
                     if ($tokens[$beforeUsage]['code'] === T_DOC_COMMENT_TAG
                         && in_array($tokens[$beforeUsage]['content'], CodingStandard::TAG_WITH_TYPE, true)
                     ) {
+                        return;
+                    }
+
+                    if ($match) {
                         return;
                     }
                 } else {

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
@@ -39,6 +39,12 @@ use BarBaz\Unused14;
 use Unused15;
 use Used19;
 use Used20;
+use Used21;
+use Used22;
+use FooBar;
+use FooB;
+use Unused16;
+use Unused17;
 
 /**
  * @Used10
@@ -122,5 +128,12 @@ class Foo
         new Hey \ /** @todo */ Unused13();
         new /** hey */ Used18 \ World();
         MyClass::Unused14;
+    }
+
+    /**
+     * @Used21(param=@Used22, value=@Used23, key=@FooBar, foo="@Unused16", bar="something @Unused17 bar")
+     */
+    protected function testAnnotations()
+    {
     }
 }

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
@@ -25,6 +25,9 @@ use FooBar\Used17;
 use FooBar\Used18;
 use Used19;
 use Used20;
+use Used21;
+use Used22;
+use FooBar;
 
 /**
  * @Used10
@@ -108,5 +111,12 @@ class Foo
         new Hey \ /** @todo */ Unused13();
         new /** hey */ Used18 \ World();
         MyClass::Unused14;
+    }
+
+    /**
+     * @Used21(param=@Used22, value=@Used23, key=@FooBar, foo="@Unused16", bar="something @Unused17 bar")
+     */
+    protected function testAnnotations()
+    {
     }
 }

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.php
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.php
@@ -43,6 +43,9 @@ class UnusedUseStatementUnitTest extends AbstractTestCase
             37 => 1,
             38 => 1,
             39 => 1,
+            45 => 1,
+            46 => 1,
+            47 => 1,
         ];
     }
 


### PR DESCRIPTION
False-positive when imported class used in annotations was marked as unused and removed by `Namespaces\UnusedUseStatement` sniff.