### PR TITLE
StringClassReference - fixed regular expression to match FQCN

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Formatting/StringClassReferenceSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Formatting/StringClassReferenceSniff.php
@@ -11,8 +11,8 @@ use function class_exists;
 use function interface_exists;
 use function ltrim;
 use function preg_match;
+use function str_replace;
 use function strpos;
-use function strtr;
 use function substr;
 use function trait_exists;
 
@@ -38,17 +38,8 @@ class StringClassReferenceSniff implements Sniff
             return;
         }
 
-        $name = strtr($tokens[$stackPtr]['content'], [
-            '"' => '',
-            "'" => '',
-            '\\\\' => '\\',
-        ]);
-
-        if (strpos($name, '\\\\') !== false
-            || preg_match('/[^\\a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]/', $name)
-            || substr($name, -1) === '\\'
-            || ltrim($name, '\\') === ''
-        ) {
+        $name = substr(str_replace('\\\\', '\\', $tokens[$stackPtr]['content']), 1, -1);
+        if (! preg_match('/^(\\\\?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)+$/', $name)) {
             return;
         }
 

--- a/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc
+++ b/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc
@@ -23,3 +23,5 @@ $spaceAtTheEnd = ' WebimpressCodingStandardTest\\Ruleset ';
 
 $namespaceSeparatorAtTheEnd = 'WebimpressCodingStandardTest\\Ruleset\\';
 $justNamespaceSeparator = '\\';
+
+$quotes = '"\DateTime"';

--- a/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc.fixed
+++ b/test/Sniffs/Formatting/StringClassReferenceUnitTest.inc.fixed
@@ -23,3 +23,5 @@ $spaceAtTheEnd = ' WebimpressCodingStandardTest\\Ruleset ';
 
 $namespaceSeparatorAtTheEnd = 'WebimpressCodingStandardTest\\Ruleset\\';
 $justNamespaceSeparator = '\\';
+
+$quotes = '"\DateTime"';


### PR DESCRIPTION
Before we had wrong regular expression to match FQCN and because of that the sniff may work incorrectly.