### PR TITLE
Adds support for `@method` tag

### DIFF
--- a/src/WebimpressCodingStandard/CodingStandard.php
+++ b/src/WebimpressCodingStandard/CodingStandard.php
@@ -25,6 +25,7 @@ class CodingStandard
         '@param',
         '@return',
         '@throws',
+        '@method',
         '@property',
         '@property-read',
         '@property-write',

--- a/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
@@ -130,7 +130,7 @@ class UnusedUseStatementSniff implements Sniff
             if (($isStringToken && strtolower($tokens[$classUsed]['content']) === $lowerClassName)
                 || ($tokens[$classUsed]['code'] === T_DOC_COMMENT_STRING
                     && preg_match(
-                        '/(\s|\||^)' . preg_quote($lowerClassName, '/') . '(\s|\||\\\\|$|\[\])/i',
+                        '/(\s|\||\(|^)' . preg_quote($lowerClassName, '/') . '(\s|\||\\\\|$|\[\])/i',
                         $tokens[$classUsed]['content']
                     ))
                 || ($tokens[$classUsed]['code'] === T_DOC_COMMENT_TAG

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
@@ -45,8 +45,19 @@ use FooBar;
 use FooB;
 use Unused16;
 use Unused17;
+use Used23;
+use Used24;
+use Used25;
+use Used26;
+use Used27;
+use Used28;
 
 /**
+ * @method Used23 myMethod(Used24 $param1, Used25 $param2)
+ * @property Used26 $foo
+ * @property-read Used27 $bar
+ * @property-write Used28 $baz
+ *
  * @Used10
  * @Used11\Table
  * @AliasUsed12(...)

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
@@ -28,8 +28,19 @@ use Used20;
 use Used21;
 use Used22;
 use FooBar;
+use Used23;
+use Used24;
+use Used25;
+use Used26;
+use Used27;
+use Used28;
 
 /**
+ * @method Used23 myMethod(Used24 $param1, Used25 $param2)
+ * @property Used26 $foo
+ * @property-read Used27 $bar
+ * @property-write Used28 $baz
+ *
  * @Used10
  * @Used11\Table
  * @AliasUsed12(...)

--- a/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.1.inc
+++ b/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.1.inc
@@ -13,6 +13,9 @@ DaTeTiMe::createFromFormat();
 
 /**
  * @property ArrayObject $ao
+ * @property-read ArrayObject $aor
+ * @property-write ArrayObject $aow
+ * @method ArrayObject method(ArrayObject|Datetime $p1, null|Arrayaccess $p2)
  */
 class CorrectClassNameCase
 {

--- a/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.1.inc.fixed
+++ b/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.1.inc.fixed
@@ -13,6 +13,9 @@ DateTime::createFromFormat();
 
 /**
  * @property AO $ao
+ * @property-read AO $aor
+ * @property-write AO $aow
+ * @method AO method(AO|DateTime $p1, null|ArrayAccess $p2)
  */
 class CorrectClassNameCase
 {

--- a/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.php
+++ b/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.php
@@ -20,6 +20,9 @@ class CorrectClassNameCaseUnitTest extends AbstractTestCase
                     10 => 1,
                     12 => 1,
                     15 => 1,
+                    16 => 1,
+                    17 => 1,
+                    18 => 3,
                 ];
             case 'CorrectClassNameCaseUnitTest.2.inc':
                 return [

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.3.inc
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.3.inc
@@ -8,6 +8,7 @@ use ImportedClass;
  * Class MyClass
  *
  * @package MyNamespace
+ * @method \Other\MethodReturn myMethod(\Other\Param1 $param1, \Other\Param2|\MyNamespace\Param2Other $param2)
  * @property \MyNamespace\Date $date
  * @property \MyNamespace\Service\DateService $dateService
  * @property-read \DateTime $dateTime

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.3.inc.fixed
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.3.inc.fixed
@@ -2,6 +2,9 @@
 
 namespace MyNamespace;
 
+use Other\MethodReturn;
+use Other\Param1;
+use Other\Param2;
 use DateTime;
 use ArrayObject;
 use ArrayAccess;
@@ -17,6 +20,7 @@ use ImportedClass;
  * Class MyClass
  *
  * @package MyNamespace
+ * @method MethodReturn myMethod(Param1 $param1, Param2|Param2Other $param2)
  * @property Date $date
  * @property Service\DateService $dateService
  * @property-read DateTime $dateTime

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.php
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.php
@@ -32,18 +32,19 @@ class DisallowFqnUnitTest extends AbstractTestCase
                 ];
             case 'DisallowFqnUnitTest.3.inc':
                 return [
-                    11 => 1,
+                    11 => 3,
                     12 => 1,
                     13 => 1,
                     14 => 1,
-                    19 => 1,
-                    24 => 1,
+                    15 => 1,
+                    20 => 1,
                     25 => 1,
-                    32 => 1,
+                    26 => 1,
                     33 => 1,
-                    35 => 1,
-                    41 => 1,
+                    34 => 1,
+                    36 => 1,
                     42 => 1,
+                    43 => 1,
                 ];
         }
 


### PR DESCRIPTION
Support has been added to the followin sniffs:
- `Namespaces\UnusedUseStatement`
- `PHP\CorrectClassNameCase`
- `PHP\DisallowFqn`

Includes unit tests.