### PR TITLE
Fixes regular expression to check class name

### DIFF
--- a/src/WebimpressCodingStandard/Helper/MethodsTrait.php
+++ b/src/WebimpressCodingStandard/Helper/MethodsTrait.php
@@ -399,6 +399,11 @@ trait MethodsTrait
             return true;
         }
 
-        return (bool) preg_match('/^((?:\\\\?[a-z0-9]+)+(?:\[\])*)(\|(?:\\\\?[a-z0-9]+)+(?:\[\])*)*$/i', $type);
+        $classRegexp = '\\\\?[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*';
+
+        return (bool) preg_match(
+            '/^((?:' . $classRegexp . ')+(?:\[\])*)(\|(?:' . $classRegexp . ')+(?:\[\])*)*$/i',
+            $type
+        );
     }
 }

--- a/src/WebimpressCodingStandard/Sniffs/Functions/ParamSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Functions/ParamSniff.php
@@ -10,7 +10,6 @@ use WebimpressCodingStandard\Helper\MethodsTrait;
 
 use function array_filter;
 use function array_merge;
-use function count;
 use function current;
 use function explode;
 use function implode;
@@ -321,7 +320,6 @@ class ParamSniff implements Sniff
             }
         }
 
-        $count = count($types);
         $break = false;
         foreach ($types as $key => $type) {
             $lower = strtolower($type);

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.inc
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.inc
@@ -2,9 +2,17 @@
 
 namespace MyNamespace\Test;
 
-class TagWithType {
+class TagWithType
+{
+    /** @var \Property_Type */
+    public $className;
+
     /**
-     * @throws \Exception
+     * @param \Param_Type $param
+     * @return \Return_Type
+     * @throws \Exception_Name
      */
-    public function test() {}
+    public function test(\Param_Type $param) : \Return_Type
+    {
+    }
 }

--- a/test/Sniffs/Functions/ParamUnitTest.1.inc
+++ b/test/Sniffs/Functions/ParamUnitTest.1.inc
@@ -137,5 +137,10 @@ class FunctionParam
     /**
      * @param int,string $a
      */
-    public function invalidType($a);
+    abstract public function invalidType($a);
+
+    /**
+     * @param Other_Param $Foo
+     */
+    public function withUnderscore(With_Underscore $a, $foo = null) {}
 }

--- a/test/Sniffs/Functions/ParamUnitTest.php
+++ b/test/Sniffs/Functions/ParamUnitTest.php
@@ -27,6 +27,7 @@ class ParamUnitTest extends AbstractTestCase
                     98 => 1,
                     130 => 1,
                     135 => 1,
+                    143 => 2,
                 ];
         }
 

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.inc
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.inc
@@ -254,4 +254,17 @@ abstract class FunctionCommentReturn
     {
         return $this->thisParent();
     }
+
+    public function withReturnType($a): \Return_Type
+    {
+        return $a;
+    }
+
+    /**
+     * @return \Return_Type
+     */
+    public function withDocBlock($a)
+    {
+        return $a;
+    }
 }


### PR DESCRIPTION
Regular expression was used in the following sniffs:
- `Commenting\TagWithType`
- `Functions\Param`
- `Functions\ReturnType`

Unit tests included.