### PR TITLE
Fixes issue with invalid type in PHPDoc - fixer infinite loop

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/PHP/CorrectClassNameCaseSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/PHP/CorrectClassNameCaseSniff.php
@@ -20,6 +20,7 @@ use function get_declared_traits;
 use function implode;
 use function in_array;
 use function ltrim;
+use function preg_match;
 use function preg_match_all;
 use function preg_quote;
 use function preg_replace;
@@ -313,6 +314,10 @@ class CorrectClassNameCaseSniff implements Sniff
     private function getExpectedName(File $phpcsFile, string $class, int $stackPtr) : string
     {
         $suffix = strstr($class, '[');
+        if ($suffix && ! preg_match('/^(\[\])+$/', $suffix)) {
+            return $class;
+        }
+
         $class = str_replace(['[', ']'], '', $class);
 
         $imports = $this->getGlobalUses($phpcsFile);

--- a/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.inc
+++ b/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.inc
@@ -91,4 +91,9 @@ class MyClass
     public function trav(iterable $a)
     {
     }
+
+    /**
+     * @param \Bar[]\Foo[] $param
+     */
+    abstract public function invalidTypeFormatIsNotChanged($param);
 }

--- a/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.inc.fixed
+++ b/test/Sniffs/PHP/CorrectClassNameCaseUnitTest.inc.fixed
@@ -91,4 +91,9 @@ class MyClass
     public function trav(iterable $a)
     {
     }
+
+    /**
+     * @param \Bar[]\Foo[] $param
+     */
+    abstract public function invalidTypeFormatIsNotChanged($param);
 }

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.inc
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.inc
@@ -144,4 +144,9 @@ class TheClass extends \ MyNamespace \ Hello \ ParentClass implements \ArrayAcce
             }
         };
     }
+
+    /**
+     * @param \Bar[]\Foo[] $param
+     */
+    abstract public function invalidTypeFormatIsNotChanged($param);
 }

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.inc.fixed
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.inc.fixed
@@ -169,4 +169,9 @@ class TheClass extends ParentClass      implements ArrayAccess, Countable
             }
         };
     }
+
+    /**
+     * @param \Bar[]\Foo[] $param
+     */
+    abstract public function invalidTypeFormatIsNotChanged($param);
 }


### PR DESCRIPTION
Affected sniffs:
- `PHP\CorrectClassNameCase`
- `PHP\DisallowFqn`