### PR TITLE
Fixes sorting class names (global import, traits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#31](https://github.com/webimpress/coding-standard/pull/31) `WhiteSpace\BraceBlankLine` - fixes fixer conflict with empty structures
 
+- [#33](https://github.com/webimpress/coding-standard/pull/33) fixes sorting issue of imported class and traits usage. Fixes the following sniffs:
+    - `Classes\AlphabeticallySortedTraits`
+    - `Namespaces\AlphabeticallySortedUses`
+
 ## 1.0.3 - 2019-05-28
 
 ### Added

--- a/src/WebimpressCodingStandard/Sniffs/Classes/AlphabeticallySortedTraitsSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Classes/AlphabeticallySortedTraitsSniff.php
@@ -139,7 +139,7 @@ class AlphabeticallySortedTraitsSniff implements Sniff
 
     private function clearName(string $name) : string
     {
-        return str_replace('\\', ':', $name);
+        return str_replace('\\', ' ', $name);
     }
 
     /**

--- a/src/WebimpressCodingStandard/Sniffs/Namespaces/AlphabeticallySortedUsesSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Namespaces/AlphabeticallySortedUsesSniff.php
@@ -213,7 +213,7 @@ class AlphabeticallySortedUsesSniff implements Sniff
 
     private function clearName(string $name) : string
     {
-        return str_replace('\\', ':', $name);
+        return str_replace('\\', ' ', $name);
     }
 
     /**

--- a/test/Sniffs/Classes/AlphabeticallySortedTraitsUnitTest.inc
+++ b/test/Sniffs/Classes/AlphabeticallySortedTraitsUnitTest.inc
@@ -37,5 +37,12 @@ class Foo
         };
 
         $closure = function () use ($x) {};
+
+        $class = new class {
+            use Psr\NamespaceSeparator;
+            use PSR7Number;
+            use Psr_Underscore;
+            use PsrLetter;
+        };
     }
 }

--- a/test/Sniffs/Classes/AlphabeticallySortedTraitsUnitTest.inc.fixed
+++ b/test/Sniffs/Classes/AlphabeticallySortedTraitsUnitTest.inc.fixed
@@ -36,5 +36,12 @@ use BTrait;
         };
 
         $closure = function () use ($x) {};
+
+        $class = new class {
+            use Psr\NamespaceSeparator;
+            use PSR7Number;
+            use Psr_Underscore;
+            use PsrLetter;
+        };
     }
 }

--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc
@@ -36,3 +36,10 @@ namespace C {
 
     use const PHP_EOL; use const PHP_VERSION_ID;
 }
+
+namespace D {
+    use Psr\NamespaceSeparator;
+    use PSR7Number;
+    use Psr_Underscore;
+    use PsrLetter;
+}

--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc.fixed
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc.fixed
@@ -39,3 +39,10 @@ namespace C {
     use const PHP_EOL;
  use const PHP_VERSION_ID;
 }
+
+namespace D {
+    use Psr\NamespaceSeparator;
+    use PSR7Number;
+    use Psr_Underscore;
+    use PsrLetter;
+}


### PR DESCRIPTION
Affected sniffs:
- `Classes\AlphabeticallySortedTraits`
- `Namespaces\AlphabeticallySortedUses`

Fixes #32