### PR TITLE
Fix invalid fixer behaviour (no namespace, imported class, fcqn)

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/PHP/CorrectClassNameCaseSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/PHP/CorrectClassNameCaseSniff.php
@@ -433,7 +433,7 @@ class CorrectClassNameCaseSniff implements Sniff
 
                 foreach ($imports as $alias => $import) {
                     if (strtolower($import['fqn']) === strtolower($fullClassName)) {
-                        $this->error($phpcsFile, $start, $end, $import['name'], $class);
+                        $this->error($phpcsFile, $start, $end, $import['name'], $class, $import['ptr']);
                         return;
                     }
                 }
@@ -455,8 +455,14 @@ class CorrectClassNameCaseSniff implements Sniff
     /**
      * Reports new fixable error.
      */
-    private function error(File $phpcsFile, int $start, int $end, string $expected, string $actual) : void
-    {
+    private function error(
+        File $phpcsFile,
+        int $start,
+        int $end,
+        string $expected,
+        string $actual,
+        ?int $ptr = null
+    ) : void {
         $error = 'Expected class name %s; found %s';
         $data = [
             $expected,
@@ -466,6 +472,11 @@ class CorrectClassNameCaseSniff implements Sniff
 
         if ($fix) {
             $phpcsFile->fixer->beginChangeset();
+            if ($ptr) {
+                $content = $phpcsFile->getTokens()[$ptr]['content'];
+                $phpcsFile->fixer->replaceToken($ptr, '');
+                $phpcsFile->fixer->addContentBefore($ptr + 1, $content);
+            }
             for ($i = $start; $i < $end - 1; $i++) {
                 $phpcsFile->fixer->replaceToken($i, '');
             }

--- a/test/Integration/NoNamespaceImport.php
+++ b/test/Integration/NoNamespaceImport.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use MyApp\MyClass;
+
+return [
+    MyApp\MyClass::class,
+];

--- a/test/Integration/NoNamespaceImport.php.fixed
+++ b/test/Integration/NoNamespaceImport.php.fixed
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    MyApp\MyClass::class,
+];


### PR DESCRIPTION
In case of file without namespace, when we have imported class and also used the same class with fcqn in the file (without leading `\`) import was removed and fcqn was replaced with the imported name. It leads to invalid class name in the file. Only import should be removed.