### PR TITLE
Feature: PHP\StaticCallback sniff

### DIFF
--- a/src/WebimpressCodingStandard/Helper/NamespacesTrait.php
+++ b/src/WebimpressCodingStandard/Helper/NamespacesTrait.php
@@ -157,7 +157,7 @@ trait NamespacesTrait
         $allConstants = get_defined_constants(true);
 
         $arr = [];
-        array_walk_recursive($allConstants, function ($v, $k) use (&$arr) {
+        array_walk_recursive($allConstants, static function ($v, $k) use (&$arr) {
             if (strtolower($k) !== 'user') {
                 $arr[$k] = $v;
             }

--- a/src/WebimpressCodingStandard/Sniffs/Classes/AlphabeticallySortedTraitsSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Classes/AlphabeticallySortedTraitsSniff.php
@@ -160,7 +160,7 @@ class AlphabeticallySortedTraitsSniff implements Sniff
             return $this->compareUseStatements($a, $b);
         });
 
-        $phpcsFile->fixer->addContent($first['ptrUse'], implode($phpcsFile->eolChar, array_map(function ($use) {
+        $phpcsFile->fixer->addContent($first['ptrUse'], implode($phpcsFile->eolChar, array_map(static function ($use) {
             return $use['string'];
         }, $uses)));
 

--- a/src/WebimpressCodingStandard/Sniffs/Commenting/CodingStandardTagsSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/CodingStandardTagsSniff.php
@@ -64,7 +64,7 @@ class CodingStandardTagsSniff implements Sniff
         while ($next = $phpcsFile->findNext([T_COMMENT, T_DOC_COMMENT_TAG], $next + 1)) {
             if ($tokens[$next]['code'] === T_DOC_COMMENT_TAG) {
                 $lower = strtolower($tokens[$next]['content']);
-                if ($tag = key(array_filter($this->replacements, function ($key) use ($lower) {
+                if ($tag = key(array_filter($this->replacements, static function ($key) use ($lower) {
                     return strtolower($key) === $lower;
                 }, ARRAY_FILTER_USE_KEY))) {
                     $this->overrideToken($phpcsFile, $next);

--- a/src/WebimpressCodingStandard/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/FunctionCommentSniff.php
@@ -155,7 +155,7 @@ class FunctionCommentSniff implements Sniff
                 $last = $i;
                 while (isset($tags[$key + 1]) && $tags[$key + 1] < $i) {
                     $tagName = strtolower($tokens[$tags[$key + 1]]['content']);
-                    if (! array_filter($this->nestedTags, function ($v) use ($tagName) {
+                    if (! array_filter($this->nestedTags, static function ($v) use ($tagName) {
                         return strtolower($v) === $tagName;
                     })) {
                         $error = 'Tag %s cannot be nested';

--- a/src/WebimpressCodingStandard/Sniffs/Commenting/FunctionDisallowedTagSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/FunctionDisallowedTagSniff.php
@@ -73,7 +73,7 @@ class FunctionDisallowedTagSniff implements Sniff
         $commentStart = $tokens[$commentEnd]['comment_opener'];
         foreach ($tokens[$commentStart]['comment_tags'] as $tag) {
             $content = strtolower($tokens[$tag]['content']);
-            $result = array_filter($this->disallowedTags, function ($key) use ($content) {
+            $result = array_filter($this->disallowedTags, static function ($key) use ($content) {
                 return strtolower($key) === $content;
             }, ARRAY_FILTER_USE_KEY);
 

--- a/src/WebimpressCodingStandard/Sniffs/Commenting/TagWithTypeSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/TagWithTypeSniff.php
@@ -326,7 +326,7 @@ class TagWithTypeSniff implements Sniff
                 && ($lower === 'mixed' || strpos($lower, 'mixed[') === 0)
             ) {
                 if ($count > 2
-                    || ! array_filter($this->types, function ($type) {
+                    || ! array_filter($this->types, static function ($type) {
                         return strtolower($type) === 'null';
                     })
                 ) {
@@ -427,7 +427,7 @@ class TagWithTypeSniff implements Sniff
                 $fix = $phpcsFile->addFixableError($error, $tagPtr + 2, 'BoolAndTrue');
 
                 if ($fix) {
-                    $types = array_filter($this->types, function ($v) {
+                    $types = array_filter($this->types, static function ($v) {
                         return strtolower($v) !== 'true';
                     });
                     $content = trim(implode('|', $types) . ' ' . $this->description);
@@ -442,7 +442,7 @@ class TagWithTypeSniff implements Sniff
                 $fix = $phpcsFile->addFixableError($error, $tagPtr + 2, 'BoolAndFalse');
 
                 if ($fix) {
-                    $types = array_filter($this->types, function ($v) {
+                    $types = array_filter($this->types, static function ($v) {
                         return strtolower($v) !== 'false';
                     });
                     $content = trim(implode('|', $types) . ' ' . $this->description);
@@ -456,7 +456,7 @@ class TagWithTypeSniff implements Sniff
             $fix = $phpcsFile->addFixableError($error, $tagPtr + 2, 'TrueAndFalse');
 
             if ($fix) {
-                $types = array_filter($this->types, function ($v) {
+                $types = array_filter($this->types, static function ($v) {
                     return ! in_array(strtolower($v), ['true', 'false'], true);
                 });
                 $types[] = 'bool';

--- a/src/WebimpressCodingStandard/Sniffs/Commenting/VariableCommentSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/VariableCommentSniff.php
@@ -100,7 +100,7 @@ class VariableCommentSniff extends AbstractVariableSniff
             );
 
             $tagName = strtolower($tokens[$tag]['content']);
-            $isValidTag = array_filter(array_merge($this->allowedTags, ['@var']), function ($v) use ($tagName) {
+            $isValidTag = array_filter(array_merge($this->allowedTags, ['@var']), static function ($v) use ($tagName) {
                 return strtolower($v) === $tagName;
             });
 
@@ -132,7 +132,7 @@ class VariableCommentSniff extends AbstractVariableSniff
 
                 while (isset($tags[$key + 1]) && $tags[$key + 1] < $i) {
                     $tagName = strtolower($tokens[$tags[$key + 1]]['content']);
-                    if ($isValidTag && ! array_filter($this->nestedTags, function ($v) use ($tagName) {
+                    if ($isValidTag && ! array_filter($this->nestedTags, static function ($v) use ($tagName) {
                         return strtolower($v) === $tagName;
                     })) {
                         $error = 'Tag %s cannot be nested';

--- a/src/WebimpressCodingStandard/Sniffs/Files/DeclareStrictTypesSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Files/DeclareStrictTypesSniff.php
@@ -109,7 +109,7 @@ class DeclareStrictTypesSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $tags = array_map(function ($value) {
+        $tags = array_map(static function ($value) {
             return strtolower($value);
         }, $this->containsTags);
 

--- a/src/WebimpressCodingStandard/Sniffs/PHP/StaticCallbackSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/PHP/StaticCallbackSniff.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandard\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+use const T_ANON_CLASS;
+use const T_CLOSURE;
+use const T_STATIC;
+use const T_VARIABLE;
+use const T_WHITESPACE;
+
+class StaticCallbackSniff implements Sniff
+{
+    /**
+     * @return int[]
+     */
+    public function register() : array
+    {
+        return [T_CLOSURE];
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr) : void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $prev = $phpcsFile->findPrevious(
+            Tokens::$emptyTokens,
+            $stackPtr - 1,
+            null,
+            true
+        );
+
+        $isStatic = $prev && $tokens[$prev]['code'] === T_STATIC;
+
+        $start = $tokens[$stackPtr]['scope_opener'];
+        $close = $tokens[$stackPtr]['scope_closer'];
+        $hasThis = $this->hasThis($phpcsFile, $start, $close, [T_VARIABLE, T_ANON_CLASS]);
+
+        if (! $isStatic && ! $hasThis) {
+            $fix = $phpcsFile->addFixableError('Closure can be static', $stackPtr, 'Static');
+
+            if ($fix) {
+                $phpcsFile->fixer->addContentBefore($stackPtr, 'static ');
+            }
+
+            return;
+        }
+
+        if ($isStatic && $hasThis) {
+            $fix = $phpcsFile->addFixableError('Closure cannot be static', $stackPtr, 'NonStatic');
+
+            if ($fix) {
+                $phpcsFile->fixer->beginChangeset();
+                $phpcsFile->fixer->replaceToken($prev, '');
+                if ($tokens[$prev + 1]['code'] === T_WHITESPACE) {
+                    $phpcsFile->fixer->replaceToken($prev + 1, '');
+                }
+                $phpcsFile->fixer->endChangeset();
+            }
+        }
+    }
+
+    private function hasThis(File $phpcsFile, int $start, int $close, array $search) : bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        while ($next = $phpcsFile->findNext($search, $start + 1, $close)) {
+            if ($tokens[$next]['code'] === T_ANON_CLASS) {
+                if ($this->hasThis($phpcsFile, $next, $tokens[$next]['scope_opener'], [T_VARIABLE])) {
+                    return true;
+                }
+
+                $start = $tokens[$next]['scope_closer'];
+                continue;
+            }
+
+            if ($tokens[$next]['code'] === T_VARIABLE
+                && $tokens[$next]['content'] === '$this'
+            ) {
+                return true;
+            }
+
+            $start = $next;
+        }
+
+        return false;
+    }
+}

--- a/test/Sniffs/PHP/StaticCallbackUnitTest.inc
+++ b/test/Sniffs/PHP/StaticCallbackUnitTest.inc
@@ -1,0 +1,60 @@
+<?php
+function() {
+    $var = 'foo';
+    return function () {
+        $bar = 'baz';
+    };
+};
+
+$x = static function () {
+    $foo = 'bar';
+};
+
+class StaticClosure
+{
+    public function __construct()
+    {
+        (function() {
+            $this->foo();
+        })();
+    }
+
+    public function foo()
+    {
+        return function () {
+            $foo = 'bar';
+
+            return new class() {
+                public function __construct()
+                {
+                    (function() {
+                        $this->bar();
+                    })();
+                }
+
+                public function bar()
+                {
+                    echo 'foo';
+                }
+            };
+        };
+    }
+
+    public function bar()
+    {
+        return function () {
+            return new class($this) {
+                public function __construct($parent)
+                {
+                }
+            };
+        };
+    }
+
+    public function baz()
+    {
+        (static function() {
+            $this->bar();
+        })();
+    }
+}

--- a/test/Sniffs/PHP/StaticCallbackUnitTest.inc.fixed
+++ b/test/Sniffs/PHP/StaticCallbackUnitTest.inc.fixed
@@ -1,0 +1,60 @@
+<?php
+static function() {
+    $var = 'foo';
+    return static function () {
+        $bar = 'baz';
+    };
+};
+
+$x = static function () {
+    $foo = 'bar';
+};
+
+class StaticClosure
+{
+    public function __construct()
+    {
+        (function() {
+            $this->foo();
+        })();
+    }
+
+    public function foo()
+    {
+        return static function () {
+            $foo = 'bar';
+
+            return new class() {
+                public function __construct()
+                {
+                    (function() {
+                        $this->bar();
+                    })();
+                }
+
+                public function bar()
+                {
+                    echo 'foo';
+                }
+            };
+        };
+    }
+
+    public function bar()
+    {
+        return function () {
+            return new class($this) {
+                public function __construct($parent)
+                {
+                }
+            };
+        };
+    }
+
+    public function baz()
+    {
+        (function() {
+            $this->bar();
+        })();
+    }
+}

--- a/test/Sniffs/PHP/StaticCallbackUnitTest.php
+++ b/test/Sniffs/PHP/StaticCallbackUnitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandardTest\Sniffs\PHP;
+
+use WebimpressCodingStandardTest\Sniffs\AbstractTestCase;
+
+class StaticCallbackUnitTest extends AbstractTestCase
+{
+    protected function getErrorList(string $testFile = '') : array
+    {
+        return [
+            2 => 1,
+            4 => 1,
+            24 => 1,
+            56 => 1,
+        ];
+    }
+
+    protected function getWarningList(string $testFile = '') : array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
When `$this` is not used within the closure context, callback can be set as `static`.