### PR TITLE
Feature: PHP\DisallowCurlyOffsetAccessBrace sniff

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/PHP/DisallowCurlyOffsetAccessBraceSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/PHP/DisallowCurlyOffsetAccessBraceSniff.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandard\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+use const T_OBJECT_OPERATOR;
+use const T_OPEN_CURLY_BRACKET;
+
+class DisallowCurlyOffsetAccessBraceSniff implements Sniff
+{
+    /**
+     * @return int[]
+     */
+    public function register() : array
+    {
+        return [T_OPEN_CURLY_BRACKET];
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr) : void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener'])) {
+            return;
+        }
+
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, $stackPtr - 1, null, true);
+        if ($tokens[$prev]['code'] === T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        $closerPtr = $tokens[$stackPtr]['bracket_closer'];
+
+        $error = 'Invalid access offset bracket, use square brackets instead of curly';
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'Invalid');
+        if ($fix) {
+            $phpcsFile->fixer->beginChangeset();
+            $phpcsFile->fixer->replaceToken($stackPtr, '[');
+            $phpcsFile->fixer->replaceToken($closerPtr, ']');
+            $phpcsFile->fixer->endChangeset();
+        }
+    }
+}

--- a/test/Sniffs/PHP/DisallowCurlyOffsetAccessBraceUnitTest.inc
+++ b/test/Sniffs/PHP/DisallowCurlyOffsetAccessBraceUnitTest.inc
@@ -1,0 +1,12 @@
+<?php
+
+class DisallowCurlyOffsetAccessBraceUnitTest
+{
+    public function test(array $arr, string $str)
+    {
+        $arr[] = $str{0};
+        $str{0} = $arr{0};
+
+        return $this->{'get' . $str}($arr);
+    }
+}

--- a/test/Sniffs/PHP/DisallowCurlyOffsetAccessBraceUnitTest.inc.fixed
+++ b/test/Sniffs/PHP/DisallowCurlyOffsetAccessBraceUnitTest.inc.fixed
@@ -1,0 +1,12 @@
+<?php
+
+class DisallowCurlyOffsetAccessBraceUnitTest
+{
+    public function test(array $arr, string $str)
+    {
+        $arr[] = $str[0];
+        $str[0] = $arr[0];
+
+        return $this->{'get' . $str}($arr);
+    }
+}

--- a/test/Sniffs/PHP/DisallowCurlyOffsetAccessBraceUnitTest.php
+++ b/test/Sniffs/PHP/DisallowCurlyOffsetAccessBraceUnitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandardTest\Sniffs\PHP;
+
+use WebimpressCodingStandardTest\Sniffs\AbstractTestCase;
+
+class DisallowCurlyOffsetAccessBraceUnitTest extends AbstractTestCase
+{
+    protected function getErrorList(string $testFile = '') : array
+    {
+        return [
+            7 => 1,
+            8 => 2,
+        ];
+    }
+
+    protected function getWarningList(string $testFile = '') : array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
As of PHP 7.4:

> the array and string offset access syntax using curly braces is deprecated.
