### PR TITLE
Feature: ControlStructures\DefaultAsLast

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/ControlStructures/DefaultAsLastSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/ControlStructures/DefaultAsLastSniff.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandard\Sniffs\ControlStructures;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+use function array_reverse;
+use function key;
+
+use const T_CASE;
+use const T_DEFAULT;
+
+class DefaultAsLastSniff implements Sniff
+{
+    /**
+     * @return int[]
+     */
+    public function register() : array
+    {
+        return [T_DEFAULT];
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr) : void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $default = $tokens[$stackPtr];
+        $switchPtr = key(array_reverse($default['conditions'], true));
+        $closer = $tokens[$switchPtr]['scope_closer'];
+
+        $from = $stackPtr;
+
+        while ($casePtr = $phpcsFile->findNext(T_CASE, $from + 1, $closer)) {
+            if ($switchPtr === key(array_reverse($tokens[$casePtr]['conditions'], true))) {
+                $error = 'Default case in switch should be as last; another case found here';
+                $phpcsFile->addError($error, $casePtr, 'CaseAfterDefault');
+                break;
+            }
+
+            $from = $casePtr;
+        }
+    }
+}

--- a/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.inc
+++ b/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.inc
@@ -1,0 +1,21 @@
+<?php
+
+switch (true) {
+    case 1:
+        break;
+    case 2:
+        break;
+    default:
+        break;
+    case 3:
+        switch (true) {
+            case 1:
+                break;
+            default:
+                break;
+            case 2:
+                break;
+        }
+    case 4:
+        break;
+}

--- a/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.inc
+++ b/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.inc
@@ -6,8 +6,6 @@ switch (true) {
     case 2:
         break;
     default:
-        break;
-    case 3:
         switch (true) {
             case 1:
                 break;
@@ -16,6 +14,7 @@ switch (true) {
             case 2:
                 break;
         }
+        break;
     case 4:
         break;
 }

--- a/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.php
+++ b/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.php
@@ -11,8 +11,8 @@ class DefaultAsLastUnitTest extends AbstractTestCase
     protected function getErrorList(string $testFile = '') : array
     {
         return [
-            10 => 1,
-            16 => 1,
+            14 => 1,
+            18 => 1,
         ];
     }
 

--- a/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.php
+++ b/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandardTest\Sniffs\ControlStructures;
+
+use WebimpressCodingStandardTest\Sniffs\AbstractTestCase;
+
+class DefaultAsLastUnitTest extends AbstractTestCase
+{
+    protected function getErrorList(string $testFile = '') : array
+    {
+        return [
+            10 => 1,
+            16 => 1,
+        ];
+    }
+
+    protected function getWarningList(string $testFile = '') : array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
The `default` case should be as the last case in `switch`.