### PR TITLE
Feature: all variables must be camel case - strict

### DIFF
--- a/src/WebimpressCodingStandard/Helper/MethodsTrait.php
+++ b/src/WebimpressCodingStandard/Helper/MethodsTrait.php
@@ -263,13 +263,13 @@ trait MethodsTrait
             return false;
         }
 
-        $fqcnTypeHint = strtolower($this->getFQCN($lowerTypeHint));
+        $fqcnTypeHint = strtolower($this->getFqcn($lowerTypeHint));
         foreach ($types as $key => $type) {
             if ($type === 'null') {
                 continue;
             }
 
-            $types[$key] = strtolower($this->getFQCN($type));
+            $types[$key] = strtolower($this->getFqcn($type));
         }
         $fqcnTypes = implode('|', $types);
 
@@ -279,7 +279,7 @@ trait MethodsTrait
                     || $fqcnTypeHint . '|null' === $fqcnTypes));
     }
 
-    private function getFQCN(string $class) : string
+    private function getFqcn(string $class) : string
     {
         // It is a simple type
         if (in_array(strtolower($class), $this->simpleReturnTypes, true)) {
@@ -322,7 +322,7 @@ trait MethodsTrait
         }
 
         $lowerParentClassName = strtolower($this->parentClassName);
-        $lowerFqcn = strtolower($this->getFQCN($lowerParentClassName));
+        $lowerFqcn = strtolower($this->getFqcn($lowerParentClassName));
         $lower = strtolower($name);
 
         return $lower === $lowerFqcn

--- a/src/WebimpressCodingStandard/Helper/MethodsTrait.php
+++ b/src/WebimpressCodingStandard/Helper/MethodsTrait.php
@@ -308,10 +308,10 @@ trait MethodsTrait
 
         $ns = strtolower($this->currentNamespace);
         $lowerClassName = strtolower($this->className);
-        $lowerFQCN = ($ns ? '\\' . $ns : '') . '\\' . $lowerClassName;
+        $lowerFqcn = ($ns ? '\\' . $ns : '') . '\\' . $lowerClassName;
         $lower = strtolower($name);
 
-        return $lower === $lowerFQCN
+        return $lower === $lowerFqcn
             || $lower === $lowerClassName;
     }
 
@@ -322,10 +322,10 @@ trait MethodsTrait
         }
 
         $lowerParentClassName = strtolower($this->parentClassName);
-        $lowerFQCN = strtolower($this->getFQCN($lowerParentClassName));
+        $lowerFqcn = strtolower($this->getFQCN($lowerParentClassName));
         $lower = strtolower($name);
 
-        return $lower === $lowerFQCN
+        return $lower === $lowerFqcn
             || $lower === $lowerParentClassName;
     }
 

--- a/src/WebimpressCodingStandard/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -9,6 +9,7 @@ use PHP_CodeSniffer\Sniffs\AbstractVariableSniff;
 use PHP_CodeSniffer\Util\Common;
 
 use function ltrim;
+use function preg_match_all;
 
 use const T_DOUBLE_COLON;
 use const T_WHITESPACE;
@@ -48,8 +49,8 @@ class ValidVariableNameSniff extends AbstractVariableSniff
             return; // skip MyClass::$variable, there might be no control over the declaration
         }
 
-        if (! Common::isCamelCaps($varName, false, true, false)) {
-            $error = 'Variable "%s" is not in valid camel caps format';
+        if (! Common::isCamelCaps($varName, false, true, true)) {
+            $error = 'Variable "$%s" is not in valid camel caps format';
             $data = [$varName];
             $phpcsFile->addError($error, $stackPtr, 'NotCamelCaps', $data);
         }
@@ -60,7 +61,14 @@ class ValidVariableNameSniff extends AbstractVariableSniff
      */
     protected function processMemberVar(File $phpcsFile, $stackPtr) : void
     {
-        // handled by PSR2.Classes.PropertyDeclaration
+        $tokens = $phpcsFile->getTokens();
+        $varName = ltrim($tokens[$stackPtr]['content'], '$');
+
+        if (! Common::isCamelCaps($varName, false, true, true)) {
+            $error = 'Property "$%s" is not in valid camel caps format';
+            $data = [$varName];
+            $phpcsFile->addError($error, $stackPtr, 'NotCamelCapsProperty', $data);
+        }
     }
 
     /**
@@ -68,6 +76,20 @@ class ValidVariableNameSniff extends AbstractVariableSniff
      */
     protected function processVariableInString(File $phpcsFile, $stackPtr) : void
     {
-        // handled by Squiz.Strings.DoubleQuoteUsage
+        $tokens = $phpcsFile->getTokens();
+        $content = $tokens[$stackPtr]['content'];
+
+        $pattern = '|(?<!\\\\)(?:\\\\{2})*\${?([a-zA-Z0-9_]+)}?|';
+        if (! preg_match_all($pattern, $content, $matches)) {
+            return;
+        }
+
+        foreach ($matches[1] as $varName) {
+            if (! Common::isCamelCaps($varName, false, true, true)) {
+                $error = 'Variable "$%s" is not in valid camel caps format';
+                $data = [$varName];
+                $phpcsFile->addError($error, $stackPtr, 'NotCamelCapsInString', $data);
+            }
+        }
     }
 }

--- a/src/WebimpressCodingStandard/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -80,11 +80,9 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         $content = $tokens[$stackPtr]['content'];
 
         $pattern = '|(?<!\\\\)(?:\\\\{2})*\${?([a-zA-Z0-9_]+)}?|';
-        if (! preg_match_all($pattern, $content, $matches)) {
-            return;
-        }
+        preg_match_all($pattern, $content, $matches);
 
-        foreach ($matches[1] as $varName) {
+        foreach ($matches[1] ?? [] as $varName) {
             if (! Common::isCamelCaps($varName, false, true, true)) {
                 $error = 'Variable "$%s" is not in valid camel caps format';
                 $data = [$varName];

--- a/src/WebimpressCodingStandard/ruleset.xml
+++ b/src/WebimpressCodingStandard/ruleset.xml
@@ -27,6 +27,8 @@
         <!-- Replaced by WebimpressCodingStandard.WhiteSpace.CommaSpacing -->
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma"/>
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg"/>
+        <!-- Replaced by WebimpressCodingStandard.NamingConventions.ValidVariableName -->
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
     </rule>
 
     <!-- Generic Rules -->

--- a/test/Sniffs/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/test/Sniffs/NamingConventions/ValidVariableNameUnitTest.inc
@@ -21,9 +21,14 @@ echo \Library::$_variable;
 echo \Library::$_another_variable;
 
 class Foo {
-    protected $_this_is_not_handled_by_this_sniff;
+    protected $_invalid;
+    protected $userID;
 }
 
-$string = "This $_some_variable is not {$handled_by} this sniff.";
+$string = "This {$_some_variable} is now ${handled_by} this $sniff.";
 $string .= $_some_variable;
 $string .= $camelCase;
+$string .= "{$myIP}";
+
+$userID = 'invalid due to two uppercase characters next to each other';
+$InvalidVariable = 'as first letter cannot be uppercase';

--- a/test/Sniffs/NamingConventions/ValidVariableNameUnitTest.inc
+++ b/test/Sniffs/NamingConventions/ValidVariableNameUnitTest.inc
@@ -31,4 +31,4 @@ $string .= $camelCase;
 $string .= "{$myIP}";
 
 $userID = 'invalid due to two uppercase characters next to each other';
-$InvalidVariable = 'as first letter cannot be uppercase';
+$InvalidVariable = "as first letter cannot be uppercase";

--- a/test/Sniffs/NamingConventions/ValidVariableNameUnitTest.php
+++ b/test/Sniffs/NamingConventions/ValidVariableNameUnitTest.php
@@ -13,7 +13,13 @@ class ValidVariableNameUnitTest extends AbstractTestCase
         return [
             15 => 1,
             16 => 1,
-            28 => 1,
+            24 => 1,
+            25 => 1,
+            28 => 2,
+            29 => 1,
+            31 => 1,
+            33 => 1,
+            34 => 1,
         ];
     }
 


### PR DESCRIPTION
Defined variables, variables used in strings and class properties must
be now camelCased (strict) - so two capital letters next to each other
are not allowed

Disable `PSR2.Classes.PropertyDeclaration.Underscore` as it is now covered
in `Webimpress\NamingConventions\ValidVariableName` sniff.