### PR TITLE
Feature: replace PSR1.Methods.CamelCapsMethodName with Generic.Naming Conventions.CamelCapsFunctionName

### DIFF
--- a/src/WebimpressCodingStandard/ruleset.xml
+++ b/src/WebimpressCodingStandard/ruleset.xml
@@ -29,6 +29,8 @@
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg"/>
         <!-- Replaced by WebimpressCodingStandard.NamingConventions.ValidVariableName -->
         <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
+        <!-- Replaced by Generic.NamingConventions.CamelCapsFunctionName -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName"/>
     </rule>
 
     <!-- Generic Rules -->
@@ -47,6 +49,7 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName"/>
     <rule ref="Generic.PHP.DiscourageGoto"/>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>


### PR DESCRIPTION
Sniff `Generic.NamingConventions.CamelCapsFunctionName` requires function and method names to be in camelCase format (strict)