### PR TITLE
Feature: Commenting\TagName sniff

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Commenting/TagNameSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/TagNameSniff.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandard\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+use function rtrim;
+
+use const T_DOC_COMMENT_TAG;
+
+class TagNameSniff implements Sniff
+{
+    /**
+     * @var string Characters disallowed at the end of the PHPDoc tag name
+     */
+    public $disallowedEndChars = ':;';
+
+    /**
+     * @return int[]
+     */
+    public function register() : array
+    {
+        return [T_DOC_COMMENT_TAG];
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $content = $tokens[$stackPtr]['content'];
+        $newContent = rtrim($content, $this->disallowedEndChars);
+
+        if ($content !== $newContent) {
+            $error = 'Invalid tag name found %s, expected %s';
+            $data = [
+                $content,
+                $newContent,
+            ];
+
+            $fix = $phpcsFile->addFixableError($error, $stackPtr, 'DisallowedEndChars', $data);
+            if ($fix) {
+                $phpcsFile->fixer->replaceToken($stackPtr, $newContent);
+            }
+        }
+    }
+}

--- a/src/WebimpressCodingStandard/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -23,7 +23,7 @@ use const T_WHITESPACE;
  * After comma should be exactly one comma.
  * There is allowed more than one space after comma only in when this is multidimensional array.
  *
- * @todo: maybe we need fix part for multidimensional array, now it's checking for something like:
+ * @todo maybe we need fix part for multidimensional array, now it's checking for something like:
  *     [
  *         [1,    3423, 342, 4324],
  *         [4432, 43,   4,   32],

--- a/test/Sniffs/Commenting/TagNameUnitTest.inc
+++ b/test/Sniffs/Commenting/TagNameUnitTest.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @todo: hello
+ * @todo: hi
+ * @todo; hola
+ * @todo;;;
+ * @todo:;::
+ */
+
+/**
+ * @var; int $var
+ */
+
+/**
+ * @myCustomTag:;
+ */
+
+/**
+ * @tag : space
+ */

--- a/test/Sniffs/Commenting/TagNameUnitTest.inc.fixed
+++ b/test/Sniffs/Commenting/TagNameUnitTest.inc.fixed
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @todo hello
+ * @todo hi
+ * @todo hola
+ * @todo
+ * @todo
+ */
+
+/**
+ * @var int $var
+ */
+
+/**
+ * @myCustomTag
+ */
+
+/**
+ * @tag : space
+ */

--- a/test/Sniffs/Commenting/TagNameUnitTest.php
+++ b/test/Sniffs/Commenting/TagNameUnitTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandardTest\Sniffs\Commenting;
+
+use WebimpressCodingStandardTest\Sniffs\AbstractTestCase;
+
+class TagNameUnitTest extends AbstractTestCase
+{
+    protected function getErrorList(string $testFile = '') : array
+    {
+        return [
+            4 => 1,
+            5 => 1,
+            6 => 1,
+            7 => 1,
+            8 => 1,
+            12 => 1,
+            16 => 1,
+        ];
+    }
+
+    protected function getWarningList(string $testFile = '') : array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Check tags if there are any disallowed characters at the end of the name.
By defualt configured with `:` and `;` but can be set to any charactes
by configuration option `disallowedEndChars`.