### PR TITLE
Feature: Commenting\TagWithType ability to configure null to be at the end

### DIFF
--- a/src/WebimpressCodingStandard/Helper/MethodsTrait.php
+++ b/src/WebimpressCodingStandard/Helper/MethodsTrait.php
@@ -149,11 +149,11 @@ trait MethodsTrait
         $b = strtolower(str_replace('\\', ':', $b));
 
         if ($a === 'null' || strpos($a, 'null[') === 0) {
-            return -1;
+            return $this->nullPosition === 'last' ? 1 : -1;
         }
 
         if ($b === 'null' || strpos($b, 'null[') === 0) {
-            return 1;
+            return $this->nullPosition === 'last' ? -1 : 1;
         }
 
         if ($a === 'true' || $a === 'false') {

--- a/src/WebimpressCodingStandard/Sniffs/Commenting/TagWithTypeSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/TagWithTypeSniff.php
@@ -27,6 +27,7 @@ use function trim;
 use function ucfirst;
 use function usort;
 
+use const T_DOC_COMMENT_CLOSE_TAG;
 use const T_DOC_COMMENT_OPEN_TAG;
 use const T_DOC_COMMENT_STRING;
 use const T_DOC_COMMENT_TAG;
@@ -44,6 +45,11 @@ class TagWithTypeSniff implements Sniff
         '@return',
         '@var',
     ];
+
+    /**
+     * @var string Allowed values: "first", "last"
+     */
+    public $nullPosition = 'first';
 
     /**
      * @var null|string
@@ -481,7 +487,8 @@ class TagWithTypeSniff implements Sniff
             $fix = $phpcsFile->addFixableError($error, $tagPtr + 2, 'InvalidOrder', $data);
 
             if ($fix) {
-                $content = trim($content . ' ' . $this->description);
+                $content = trim($content . ' ' . $this->description)
+                    . ($phpcsFile->getTokens()[$tagPtr + 3]['code'] === T_DOC_COMMENT_CLOSE_TAG ? ' ' : '');
                 $phpcsFile->fixer->replaceToken($tagPtr + 2, $content);
             }
         }

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc
@@ -305,3 +305,11 @@ class VarTag extends VarTagParent {
      */
     public $a;
 }
+
+// @phpcs:set WebimpressCodingStandard.Commenting.TagWithType nullPosition last
+
+/** @var string|null $var */
+$var = 'abc';
+
+/** @var null|int $bar */
+$bar = $var ? 12 : null;

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc.fixed
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc.fixed
@@ -305,3 +305,11 @@ class VarTag extends VarTagParent {
      */
     public $a;
 }
+
+// @phpcs:set WebimpressCodingStandard.Commenting.TagWithType nullPosition last
+
+/** @var string|null $var */
+$var = 'abc';
+
+/** @var int|null $bar */
+$bar = $var ? 12 : null;

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.php
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.php
@@ -181,6 +181,7 @@ class TagWithTypeUnitTest extends AbstractTestCase
                     295 => 1,
                     299 => 1,
                     304 => 1,
+                    314 => 1,
                 ];
         }
 


### PR DESCRIPTION
Added configuration option `nullPosition` with default value `first`.
The other allowed value is `last` so then `null` is going to be at the end of types list.