### PR TITLE
Feature: Commenting\DocComment - checks PHPDoc open and close tags

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Commenting/DocCommentSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/DocCommentSniff.php
@@ -78,6 +78,7 @@ class DocCommentSniff implements Sniff
             return;
         }
 
+        $this->checkTags($phpcsFile, $commentStart, $commentEnd);
         $this->checkBeforeOpen($phpcsFile, $commentStart);
         $this->checkAfterClose($phpcsFile, $commentStart, $commentEnd);
         $this->checkCommentIndents($phpcsFile, $commentStart, $commentEnd);
@@ -158,6 +159,34 @@ class DocCommentSniff implements Sniff
         }
 
         return true;
+    }
+
+    /**
+     * Check if there is no additional * with comment open and close tags
+     */
+    private function checkTags(File $phpcsFile, int $commentStart, int $commentEnd) : void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$commentStart]['content'] !== '/**') {
+            $error = 'Invalid PHPDoc open tag; expected /** but found %s';
+            $data = [$tokens[$commentStart]['content']];
+
+            $fix = $phpcsFile->addFixableError($error, $commentStart, 'InvalidOpen', $data);
+            if ($fix) {
+                $phpcsFile->fixer->replaceToken($commentStart, '/**');
+            }
+        }
+
+        if ($tokens[$commentEnd]['content'] !== '*/') {
+            $error = 'Invalid PHPDoc close tag; expected */ but found %s';
+            $data = [$tokens[$commentEnd]['content']];
+
+            $fix = $phpcsFile->addFixableError($error, $commentEnd, 'InvalidClose', $data);
+            if ($fix) {
+                $phpcsFile->fixer->replaceToken($commentEnd, '*/');
+            }
+        }
     }
 
     /**

--- a/test/Sniffs/Commenting/DocCommentUnitTest.inc
+++ b/test/Sniffs/Commenting/DocCommentUnitTest.inc
@@ -316,4 +316,11 @@ class Foo
     public function allowSpaceBetweenTwoPhpDocBlock()
     {
     }
+
+    /***
+     * @return void
+     **/
+    public function wrongAdditionalStarsWithOpenAndCloseTags()
+    {
+    }
 }

--- a/test/Sniffs/Commenting/DocCommentUnitTest.inc.fixed
+++ b/test/Sniffs/Commenting/DocCommentUnitTest.inc.fixed
@@ -318,4 +318,11 @@ $c = 'xyz';
     public function allowSpaceBetweenTwoPhpDocBlock()
     {
     }
+
+    /**
+     * @return void
+     */
+    public function wrongAdditionalStarsWithOpenAndCloseTags()
+    {
+    }
 }

--- a/test/Sniffs/Commenting/DocCommentUnitTest.php
+++ b/test/Sniffs/Commenting/DocCommentUnitTest.php
@@ -180,6 +180,8 @@ class DocCommentUnitTest extends AbstractTestCase
             258 => 1,
             259 => 1,
             260 => 1,
+            320 => 1,
+            322 => 1,
         ];
     }
 


### PR DESCRIPTION
Additional asterisk with open and close PHPDoc tags are not allowed.
Fixer replace invalid tags with short version - `/**`/`*/`.