### PR TITLE
Feature: Array\Format - disallow comments and blank lines before arrows

### DIFF
--- a/test/Sniffs/Arrays/FormatUnitTest.inc
+++ b/test/Sniffs/Arrays/FormatUnitTest.inc
@@ -87,3 +87,49 @@ $a = [
      */
     // 'key' => 'val',
 ];
+
+$a = [
+    'a',
+
+    // b
+
+    'c',
+];
+
+$a = [
+    'a',
+
+    /*
+     multiline comment
+     */
+
+    'b',
+];
+
+$x = [
+    // comment
+    'a', 'b',
+    'd',
+
+
+    // comment 1
+    'i' => 'd',
+    //comment 2
+    'j'
+
+    //comment 3
+
+    =>'r',
+
+    'r'
+    . 'x ',
+    // comment 4
+    'x1'
+
+    => 'y1',
+];
+
+$a = [
+    // COMMENT
+];
+$a = [  /**/ ];

--- a/test/Sniffs/Arrays/FormatUnitTest.inc.fixed
+++ b/test/Sniffs/Arrays/FormatUnitTest.inc.fixed
@@ -3,7 +3,6 @@ $a1 = ['foo', 'bar'];
 $a2 = [
    'foo',
  'bar',
-
   function() {
 
   },
@@ -100,3 +99,44 @@ $a = [
      */
     // 'key' => 'val',
 ];
+
+$a = [
+    'a',
+
+    // b
+    'c',
+];
+
+$a = [
+    'a',
+
+    /*
+     multiline comment
+     */
+    'b',
+];
+
+$x = [
+    // comment
+    'a',
+'b',
+    'd',
+
+
+    // comment 1
+    'i' => 'd',
+    //comment 2
+    //comment 3
+    'j'
+    =>'r',
+    'r'
+    . 'x ',
+    // comment 4
+    'x1'
+    => 'y1',
+];
+
+$a = [
+    // COMMENT
+];
+$a = [/**/];

--- a/test/Sniffs/Arrays/FormatUnitTest.php
+++ b/test/Sniffs/Arrays/FormatUnitTest.php
@@ -12,6 +12,7 @@ class FormatUnitTest extends AbstractTestCase
     {
         return [
             2 => 2,
+            6 => 1,
             14 => 2,
             16 => 2,
             19 => 1,
@@ -34,6 +35,13 @@ class FormatUnitTest extends AbstractTestCase
             74 => 1,
             75 => 1,
             76 => 1,
+            95 => 1,
+            105 => 1,
+            111 => 1,
+            120 => 1,
+            123 => 1,
+            128 => 1,
+            135 => 2,
         ];
     }
 


### PR DESCRIPTION
Using comment before arrow in array is disallowed.
Additional empty lines before arrow in array are disallowed.

Fixes also issue when empty line was not removed before the value.