### PR TITLE
Feature: Namespaces\UnusedUseStatement - support for use groups + fixes

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
@@ -19,16 +19,32 @@ use function substr;
 use function trim;
 
 use const T_AS;
+use const T_BITWISE_OR;
+use const T_CLOSE_USE_GROUP;
+use const T_COLON;
+use const T_COMMA;
+use const T_CONST;
 use const T_CURLY_OPEN;
 use const T_DOC_COMMENT_STRING;
 use const T_DOC_COMMENT_TAG;
 use const T_DOUBLE_COLON;
+use const T_ELLIPSIS;
+use const T_EXTENDS;
+use const T_FUNCTION;
+use const T_IMPLEMENTS;
+use const T_INSTANCEOF;
+use const T_INSTEADOF;
 use const T_NAMESPACE;
+use const T_NEW;
 use const T_NS_SEPARATOR;
+use const T_NULLABLE;
 use const T_OBJECT_OPERATOR;
+use const T_OPEN_PARENTHESIS;
+use const T_OPEN_USE_GROUP;
 use const T_SEMICOLON;
 use const T_STRING;
 use const T_USE;
+use const T_VARIABLE;
 use const T_WHITESPACE;
 
 /**
@@ -39,6 +55,7 @@ use const T_WHITESPACE;
  *     - added checks in annotations
  *     - added checks in return type (PHP 7.0+)
  *     - remove unused use statements in files without namespace
+ *     - support for grouped use declarations
  */
 class UnusedUseStatementSniff implements Sniff
 {
@@ -71,41 +88,223 @@ class UnusedUseStatementSniff implements Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        // Seek to the end of the statement and get the string before the semi colon.
-        // It works only with one USE keyword per declaration.
         $semiColon = $phpcsFile->findEndOfStatement($stackPtr);
-        if ($tokens[$semiColon]['code'] !== T_SEMICOLON) {
+        $prev = $phpcsFile->findPrevious(Tokens::$emptyTokens, $semiColon - 1, null, true);
+
+        if ($tokens[$prev]['code'] === T_CLOSE_USE_GROUP) {
+            $to = $prev;
+            $from = $phpcsFile->findPrevious(T_OPEN_USE_GROUP, $prev - 1);
+
+            // Empty group is invalid syntax
+            if ($phpcsFile->findNext(Tokens::$emptyTokens, $from + 1, null, true) === $to) {
+                $error = 'Empty use group';
+
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'EmptyUseGroup');
+                if ($fix) {
+                    $this->removeUse($phpcsFile, $stackPtr, $semiColon);
+                }
+
+                return;
+            }
+
+            $comma = $phpcsFile->findNext(T_COMMA, $from + 1, $to);
+            if ($comma === false
+                || $phpcsFile->findNext(Tokens::$emptyTokens, $comma + 1, $to, true) === false
+            ) {
+                $error = 'Redundant use group for one declaration';
+
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'RedundantUseGroup');
+                if ($fix) {
+                    $phpcsFile->fixer->beginChangeset();
+                    $phpcsFile->fixer->replaceToken($from, '');
+                    $i = $from + 1;
+                    while ($tokens[$i]['code'] === T_WHITESPACE) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                        ++$i;
+                    }
+
+                    if ($comma !== false) {
+                        $phpcsFile->fixer->replaceToken($comma, '');
+                    }
+
+                    $phpcsFile->fixer->replaceToken($to, '');
+                    $i = $to - 1;
+                    while ($tokens[$i]['code'] === T_WHITESPACE) {
+                        $phpcsFile->fixer->replaceToken($i, '');
+                        --$i;
+                    }
+                    $phpcsFile->fixer->endChangeset();
+                }
+
+                return;
+            }
+
+            $skip = Tokens::$emptyTokens + [T_COMMA => T_COMMA];
+
+            while ($classPtr = $phpcsFile->findPrevious($skip, $to - 1, $from + 1, true)) {
+                $to = $phpcsFile->findPrevious(T_COMMA, $classPtr - 1, $from + 1);
+
+                if (! $this->isClassUsed($phpcsFile, $stackPtr, $classPtr)) {
+                    $error = 'Unused use statement "%s"';
+                    $data = [$tokens[$classPtr]['content']];
+
+                    $fix = $phpcsFile->addFixableError($error, $classPtr, 'UnusedUseInGroup', $data);
+                    if ($fix) {
+                        $first = $to === false ? $from + 1 : $to;
+                        $last = $classPtr;
+                        if ($to === false) {
+                            $next = $phpcsFile->findNext(Tokens::$emptyTokens, $classPtr + 1, null, true);
+                            if ($tokens[$next]['code'] === T_COMMA) {
+                                $last = $next;
+                            }
+                        }
+
+                        $phpcsFile->fixer->beginChangeset();
+                        for ($i = $first; $i <= $last; ++$i) {
+                            $phpcsFile->fixer->replaceToken($i, '');
+                        }
+                        $phpcsFile->fixer->endChangeset();
+                    }
+                }
+
+                if ($to === false) {
+                    break;
+                }
+            }
+
             return;
         }
 
-        $classPtr = $phpcsFile->findPrevious(
-            Tokens::$emptyTokens,
-            $semiColon - 1,
-            null,
-            true
-        );
+        do {
+            $classPtr = $phpcsFile->findPrevious(Tokens::$emptyTokens, $semiColon - 1, null, true);
+            if (! $this->isClassUsed($phpcsFile, $stackPtr, $classPtr)) {
+                $warning = 'Unused use statement "%s"';
+                $data = [$tokens[$classPtr]['content']];
+                $fix = $phpcsFile->addFixableError($warning, $stackPtr, 'UnusedUse', $data);
+
+                if ($fix) {
+                    $prev = $phpcsFile->findPrevious(
+                        Tokens::$emptyTokens + [
+                            T_STRING => T_STRING,
+                            T_NS_SEPARATOR => T_NS_SEPARATOR,
+                            T_AS => T_AS,
+                        ],
+                        $classPtr,
+                        null,
+                        true
+                    );
+
+                    $to = $semiColon;
+                    if ($tokens[$prev]['code'] === T_COMMA) {
+                        $from = $prev;
+                        $to = $classPtr;
+                    } elseif ($tokens[$semiColon]['code'] === T_SEMICOLON) {
+                        $from = $stackPtr;
+                    } else {
+                        $from = $phpcsFile->findNext(Tokens::$emptyTokens, $prev + 1, null, true);
+                        if ($tokens[$from]['code'] === T_STRING
+                            && in_array(strtolower($tokens[$from]['content']), ['const', 'function'], true)
+                        ) {
+                            $from = $phpcsFile->findNext(Tokens::$emptyTokens, $from + 1, null, true);
+                        }
+                    }
+
+                    $this->removeUse($phpcsFile, $from, $to);
+                }
+            }
+
+            if ($tokens[$semiColon]['code'] === T_SEMICOLON) {
+                break;
+            }
+        } while ($semiColon = $phpcsFile->findEndOfStatement($semiColon + 1));
+    }
+
+    private function removeUse(File $phpcsFile, int $from, int $to) : void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $phpcsFile->fixer->beginChangeset();
+
+        // Remote whitespaces before in the same line
+        if ($tokens[$from - 1]['code'] === T_WHITESPACE
+            && $tokens[$from - 1]['line'] === $tokens[$from]['line']
+            && $tokens[$from - 2]['line'] !== $tokens[$from]['line']
+        ) {
+            $phpcsFile->fixer->replaceToken($from - 1, '');
+        }
+
+        for ($i = $from; $i <= $to; ++$i) {
+            $phpcsFile->fixer->replaceToken($i, '');
+        }
+
+        // Also remove whitespace after the semicolon (new lines).
+        if (isset($tokens[$to + 1]) && $tokens[$to + 1]['code'] === T_WHITESPACE) {
+            $phpcsFile->fixer->replaceToken($to + 1, '');
+        }
+        $phpcsFile->fixer->endChangeset();
+    }
+
+    private function isClassUsed(File $phpcsFile, int $usePtr, int $classPtr) : bool
+    {
+        $tokens = $phpcsFile->getTokens();
 
         // Search where the class name is used. PHP treats class names case
         // insensitive, that's why we cannot search for the exact class name string
         // and need to iterate over all T_STRING tokens in the file.
         $classUsed = $phpcsFile->findNext($this->checkInTokens, $classPtr + 1);
         $className = $tokens[$classPtr]['content'];
-        $lowerClassName = strtolower($className);
 
         // Check if the referenced class is in the same namespace as the current
         // file. If it is then the use statement is not necessary.
-        $namespacePtr = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr);
+        $namespacePtr = $phpcsFile->findPrevious(T_NAMESPACE, $usePtr);
 
-        // Check if the use statement does aliasing with the "as" keyword. Aliasing
-        // is allowed even in the same namespace.
-        $aliasUsed = $phpcsFile->findPrevious(T_AS, $classPtr - 1, $stackPtr);
+        $type = 'class';
+        $next = $phpcsFile->findNext(Tokens::$emptyTokens, $usePtr + 1, null, true);
+        if ($tokens[$next]['code'] === T_STRING
+            && in_array(strtolower($tokens[$next]['content']), ['const', 'function'], true)
+        ) {
+            $type = strtolower($tokens[$next]['content']);
+        }
 
-        if ($aliasUsed === false) {
-            $useNamespacePtr = $phpcsFile->findNext(T_STRING, $stackPtr + 1);
-            if (in_array(strtolower($tokens[$useNamespacePtr]['content']), ['const', 'function'], true)) {
-                ++$useNamespacePtr;
+        $searchName = $type === 'const' ? $className : strtolower($className);
+
+        $prev = $phpcsFile->findPrevious(
+            Tokens::$emptyTokens + [
+                T_STRING => T_STRING,
+                T_NS_SEPARATOR => T_NS_SEPARATOR,
+            ],
+            $classPtr - 1,
+            null,
+            $usePtr
+        );
+
+        // Only if alias is not used.
+        if ($tokens[$prev]['code'] !== T_AS) {
+            $isGroup = $tokens[$prev]['code'] === T_OPEN_USE_GROUP
+                || $phpcsFile->findPrevious(T_OPEN_USE_GROUP, $prev, $usePtr) !== false;
+
+            $useNamespace = '';
+            if ($isGroup || $tokens[$prev]['code'] !== T_COMMA) {
+                $useNamespacePtr = $type === 'class' ? $next : $next + 1;
+                $useNamespace = $this->getNamespace(
+                    $phpcsFile,
+                    $useNamespacePtr,
+                    [T_OPEN_USE_GROUP, T_COMMA, T_AS, T_SEMICOLON]
+                );
+
+                if ($isGroup) {
+                    $useNamespace .= '\\';
+                }
             }
-            $useNamespace = $this->getNamespace($phpcsFile, $useNamespacePtr, [T_AS, T_CURLY_OPEN, T_SEMICOLON]);
+
+            if ($tokens[$prev]['code'] === T_COMMA || $tokens[$prev]['code'] === T_OPEN_USE_GROUP) {
+                $useNamespace .= $this->getNamespace(
+                    $phpcsFile,
+                    $prev + 1,
+                    [T_CLOSE_USE_GROUP, T_COMMA, T_AS, T_SEMICOLON]
+                );
+            }
+
             $useNamespace = substr($useNamespace, 0, strrpos($useNamespace, '\\') ?: 0);
 
             if ($namespacePtr !== false) {
@@ -127,27 +326,30 @@ class UnusedUseStatementSniff implements Sniff
 
             $match = null;
 
-            if (($isStringToken && strtolower($tokens[$classUsed]['content']) === $lowerClassName)
-                || ($tokens[$classUsed]['code'] === T_DOC_COMMENT_STRING
-                    && preg_match(
-                        '/(\s|\||\(|^)' . preg_quote($lowerClassName, '/') . '(\s|\||\\\\|$|\[\])/i',
-                        $tokens[$classUsed]['content']
-                    ))
-                || ($tokens[$classUsed]['code'] === T_DOC_COMMENT_TAG
-                    && preg_match(
-                        '/@' . preg_quote($lowerClassName, '/') . '(\(|\\\\|$)/i',
-                        $tokens[$classUsed]['content']
-                    ))
-                || (! $isStringToken
-                    && ! preg_match(
-                        '/"[^"]*' . preg_quote($lowerClassName, '/') . '\b[^"]*"/i',
-                        $tokens[$classUsed]['content']
-                    )
-                    && preg_match(
-                        '/(?<!")@' . preg_quote($lowerClassName, '/') . '\b/i',
-                        $tokens[$classUsed]['content'],
-                        $match
-                    ))
+            if (($isStringToken
+                    && (($type !== 'const' && strtolower($tokens[$classUsed]['content']) === $searchName)
+                        || ($type === 'const' && $tokens[$classUsed]['content'] === $searchName)))
+                || ($type === 'class'
+                    && (($tokens[$classUsed]['code'] === T_DOC_COMMENT_STRING
+                            && preg_match(
+                                '/(\s|\||\(|^)' . preg_quote($searchName, '/') . '(\s|\||\\\\|$|\[\])/i',
+                                $tokens[$classUsed]['content']
+                            ))
+                        || ($tokens[$classUsed]['code'] === T_DOC_COMMENT_TAG
+                            && preg_match(
+                                '/@' . preg_quote($searchName, '/') . '(\(|\\\\|$)/i',
+                                $tokens[$classUsed]['content']
+                            ))
+                        || (! $isStringToken
+                            && ! preg_match(
+                                '/"[^"]*' . preg_quote($searchName, '/') . '\b[^"]*"/i',
+                                $tokens[$classUsed]['content']
+                            )
+                            && preg_match(
+                                '/(?<!")@' . preg_quote($searchName, '/') . '\b/i',
+                                $tokens[$classUsed]['content'],
+                                $match
+                            ))))
             ) {
                 $beforeUsage = $phpcsFile->findPrevious(
                     $isStringToken ? Tokens::$emptyTokens : $emptyTokens,
@@ -157,58 +359,113 @@ class UnusedUseStatementSniff implements Sniff
                 );
 
                 if ($isStringToken) {
-                    // If a backslash is used before the class name then this is some other
-                    // use statement.
-                    if ($tokens[$beforeUsage]['code'] !== T_USE
-                        && $tokens[$beforeUsage]['code'] !== T_NS_SEPARATOR
-                        && $tokens[$beforeUsage]['code'] !== T_OBJECT_OPERATOR
-                        && $tokens[$beforeUsage]['code'] !== T_DOUBLE_COLON
-                    ) {
-                        return;
-                    }
-
-                    // Trait use statement within a class.
-                    if ($tokens[$beforeUsage]['code'] === T_USE
-                        && ! empty($tokens[$beforeUsage]['conditions'])
-                    ) {
-                        return;
+                    if ($this->determineType($phpcsFile, $beforeUsage, $classUsed) === $type) {
+                        return true;
                     }
                 } elseif ($tokens[$classUsed]['code'] === T_DOC_COMMENT_STRING) {
                     if ($tokens[$beforeUsage]['code'] === T_DOC_COMMENT_TAG
                         && in_array($tokens[$beforeUsage]['content'], CodingStandard::TAG_WITH_TYPE, true)
                     ) {
-                        return;
+                        return true;
                     }
 
                     if ($match) {
-                        return;
+                        return true;
                     }
                 } else {
-                    return;
+                    return true;
                 }
             }
 
             $classUsed = $phpcsFile->findNext($this->checkInTokens, $classUsed + 1);
         }
 
-        $warning = 'Unused use statement "%s"';
-        $data = [$className];
-        $fix = $phpcsFile->addFixableError($warning, $stackPtr, 'UnusedUse', $data);
+        return false;
+    }
 
-        if ($fix) {
-            // Remove the whole use statement line.
-            $phpcsFile->fixer->beginChangeset();
-            for ($i = $stackPtr; $i <= $semiColon; $i++) {
-                $phpcsFile->fixer->replaceToken($i, '');
-            }
+    private function determineType(File $phpcsFile, int $beforePtr, int $ptr) : ?string
+    {
+        $tokens = $phpcsFile->getTokens();
 
-            // Also remove whitespace after the semicolon (new lines).
-            if (isset($tokens[$i]) && $tokens[$i]['code'] === T_WHITESPACE) {
-                $phpcsFile->fixer->replaceToken($i, '');
-            }
+        $beforeCode = $tokens[$beforePtr]['code'];
 
-            $phpcsFile->fixer->endChangeset();
+        if (in_array($beforeCode, [
+            T_NS_SEPARATOR,
+            T_OBJECT_OPERATOR,
+            T_DOUBLE_COLON,
+            T_FUNCTION,
+            T_CONST,
+            T_AS,
+            T_INSTEADOF,
+        ], true)) {
+            return null;
         }
+
+        if (in_array($beforeCode, [
+            T_NEW,
+            T_NULLABLE,
+            T_COLON,
+            T_EXTENDS,
+            T_IMPLEMENTS,
+            T_INSTANCEOF,
+        ], true)) {
+            return 'class';
+        }
+
+        // Trait usage
+        if ($beforeCode === T_USE && CodingStandard::isTraitUse($phpcsFile, $beforePtr)) {
+            return 'class';
+        }
+
+        if ($beforeCode === T_COMMA) {
+            $prev = $phpcsFile->findPrevious(
+                Tokens::$emptyTokens + [
+                    T_STRING => T_STRING,
+                    T_NS_SEPARATOR => T_NS_SEPARATOR,
+                ],
+                $beforePtr - 1,
+                null,
+                true
+            );
+
+            if ($tokens[$prev]['code'] === T_IMPLEMENTS || $tokens[$prev]['code'] === T_EXTENDS) {
+                return 'class';
+            }
+        }
+
+        $afterPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $ptr + 1, null, true);
+        $afterCode = $tokens[$afterPtr]['code'];
+
+        if ($afterCode === T_AS) {
+            return null;
+        }
+
+        if ($afterCode === T_OPEN_PARENTHESIS) {
+            return 'function';
+        }
+
+        if (in_array($afterCode, [T_DOUBLE_COLON, T_VARIABLE, T_ELLIPSIS], true)) {
+            return 'class';
+        }
+
+        if ($afterCode === T_BITWISE_OR) {
+            $next = $phpcsFile->findNext(
+                Tokens::$emptyTokens + [
+                    T_BITWISE_OR => T_BITWISE_OR,
+                    T_STRING => T_STRING,
+                    T_NS_SEPARATOR => T_NS_SEPARATOR,
+                ],
+                $afterPtr,
+                null,
+                true
+            );
+
+            if ($tokens[$next]['code'] === T_VARIABLE) {
+                return 'class';
+            }
+        }
+
+        return 'const';
     }
 
     private function getNamespace(File $phpcsFile, int $ptr, array $stop) : string

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.1.inc
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.1.inc
@@ -9,5 +9,27 @@ use function array_keys as k;
 use const T_WHITESPACE;
 use const T_ARRAY as TA;
 
+use function MyNamespace\{crt as foo, prt as baz};
+use const OtherNamespace\{F as O, B as A};
+
+use function X\func1, Y\func2, Z\func3;
+use const X\C1, Y\C2, Z\C3;
+
+use const ConstCaseSensitive\FOO;
+use const ConstCaseSensitive\Foo;
+use const ConstCaseSensitive\foo;
+
+use function MyNamespace\my_func;
+use const MyNamespace\MY_CONST;
+
 count([new DateTime(), T_WHITESPACE]);
 k([new AO(), TA]);
+foo(A);
+func1(func3(C2, Foo));
+
+class MyClass {
+    const MY_CONST = 1;
+    public function my_func()
+    {
+    }
+}

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.1.inc.fixed
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.1.inc.fixed
@@ -6,5 +6,23 @@ use function array_keys as k;
 
 use const T_ARRAY as TA;
 
+use function MyNamespace\crt as foo;
+use const OtherNamespace\B as A;
+
+use function X\func1, Z\func3;
+use const Y\C2;
+
+use const ConstCaseSensitive\Foo;
+
+
 count([new DateTime(), T_WHITESPACE]);
 k([new AO(), TA]);
+foo(A);
+func1(func3(C2, Foo));
+
+class MyClass {
+    const MY_CONST = 1;
+    public function my_func()
+    {
+    }
+}

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.3.inc
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.3.inc
@@ -1,0 +1,79 @@
+<?php
+
+namespace First {
+    use Unused\Hello;
+    use Unused\Foo;
+    use Unused\Baz;
+    use Used\A;
+    use Used\B;
+    use Used\C;
+    use Used\Bar;
+    use Used\Car;
+    use Used\Exception1;
+    use Used\Exception2;
+
+    use function Unused\first_func;
+    use function Unused\bar;
+    use function Unused\car;
+
+    use const Unused\BAR;
+    use const Unused\Bar;
+    use const Unused\bar;
+    use const Used\Baz;
+    use const Unused\car;
+    use const Unused\me;
+    use const Unused\other;
+
+    class FirstClass
+    {
+        use SomeTrait {
+            car as me;
+            Abc::method as hello;
+            Def::other insteadof foo;
+        }
+
+        const BAR = 1;
+
+        public function first_func(?A $a, B ...$b) : C
+        {
+        }
+
+        public function bar() : string
+        {
+            return Bar::class;
+        }
+
+        public function car() : string
+        {
+            return new Car(Baz);
+        }
+
+        public function exception() : void
+        {
+            try {
+            } catch (Exception1|Exception2|\GlobalException $ex) {
+            }
+        }
+    }
+}
+
+namespace Second {
+    use First\FirstClass;
+    use FirstClass\Something;
+    use Used\Extend1;
+    use Used\Extend2;
+    use Used\Extend3;
+    use Used\Interface1;
+    use Used\Interface2;
+    use Used\InstanceOf1;
+
+    use const Space\A;
+    use const Space\B;
+
+    $a = A|B|\Ns\C;
+
+    interface I extends Extend1, Extend2 {}
+    class C extends Extend3 implements Interface1, Interface2 {}
+
+    $b = $a instanceof InstanceOf1;
+}

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.3.inc.fixed
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.3.inc.fixed
@@ -1,0 +1,65 @@
+<?php
+
+namespace First {
+    use Used\A;
+    use Used\B;
+    use Used\C;
+    use Used\Bar;
+    use Used\Car;
+    use Used\Exception1;
+    use Used\Exception2;
+
+
+    use const Used\Baz;
+
+    class FirstClass
+    {
+        use SomeTrait {
+            car as me;
+            Abc::method as hello;
+            Def::other insteadof foo;
+        }
+
+        const BAR = 1;
+
+        public function first_func(?A $a, B ...$b) : C
+        {
+        }
+
+        public function bar() : string
+        {
+            return Bar::class;
+        }
+
+        public function car() : string
+        {
+            return new Car(Baz);
+        }
+
+        public function exception() : void
+        {
+            try {
+            } catch (Exception1|Exception2|\GlobalException $ex) {
+            }
+        }
+    }
+}
+
+namespace Second {
+    use Used\Extend1;
+    use Used\Extend2;
+    use Used\Extend3;
+    use Used\Interface1;
+    use Used\Interface2;
+    use Used\InstanceOf1;
+
+    use const Space\A;
+    use const Space\B;
+
+    $a = A|B|\Ns\C;
+
+    interface I extends Extend1, Extend2 {}
+    class C extends Extend3 implements Interface1, Interface2 {}
+
+    $b = $a instanceof InstanceOf1;
+}

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
@@ -51,6 +51,17 @@ use Used25;
 use Used26;
 use Used27;
 use Used28;
+use UnusedGroup\{Unused18, Unused19};
+use MyApp\{
+    MyNamespace\Used29,
+    OtherNamespace\Used30 as AliasUsed30,
+    Unused20
+};
+use Abc\Used31, Def\Unused21, Ghi\Used32, Jkl\Unused22;
+use FooBar\{Used33};
+use FooBar\{Used34,}; // PHP 7.2+
+use FooBar\{Unused23};
+use EmptyGroup\{};
 
 /**
  * @method Used23 myMethod(Used24 $param1, Used25 $param2)
@@ -144,7 +155,8 @@ class Foo
     /**
      * @Used21(param=@Used22, value=@Used23, key=@FooBar, foo="@Unused16", bar="something @Unused17 bar")
      */
-    protected function testAnnotations()
+    protected function testAnnotations(Used29 $u29, AliasUsed30 $u30, Used31 $u31, Used32 $u32)
     {
+        return static function (Used33 $u33, Used34 $u34) {};
     }
 }

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
@@ -17,7 +17,6 @@ use Used10;
 use Used11;
 use FooBar\Used12 as AliasUsed12;
 use FooBar\Used13;
-use Unused6, Unused7;
 use Used14;
 use Unused5\Used15;
 use Used16 as AliasUsed16;
@@ -34,6 +33,10 @@ use Used25;
 use Used26;
 use Used27;
 use Used28;
+use MyApp\OtherNamespace\Used30 as AliasUsed30;
+use Abc\Used31, Ghi\Used32;
+use FooBar\Used33;
+use FooBar\Used34; // PHP 7.2+
 
 /**
  * @method Used23 myMethod(Used24 $param1, Used25 $param2)
@@ -127,7 +130,8 @@ class Foo
     /**
      * @Used21(param=@Used22, value=@Used23, key=@FooBar, foo="@Unused16", bar="something @Unused17 bar")
      */
-    protected function testAnnotations()
+    protected function testAnnotations(Used29 $u29, AliasUsed30 $u30, Used31 $u31, Used32 $u32)
     {
+        return static function (Used33 $u33, Used34 $u34) {};
     }
 }

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.php
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.php
@@ -16,6 +16,14 @@ class UnusedUseStatementUnitTest extends AbstractTestCase
                     3 => 1,
                     6 => 1,
                     9 => 1,
+                    12 => 1,
+                    13 => 1,
+                    15 => 1,
+                    16 => 2,
+                    18 => 1,
+                    20 => 1,
+                    22 => 1,
+                    23 => 1,
                 ];
             case 'UnusedUseStatementUnitTest.2.inc':
                 return [
@@ -26,6 +34,23 @@ class UnusedUseStatementUnitTest extends AbstractTestCase
                     11 => 1,
                     12 => 1,
                 ];
+            case 'UnusedUseStatementUnitTest.3.inc':
+                return [
+                    4 => 1,
+                    5 => 1,
+                    6 => 1,
+                    15 => 1,
+                    16 => 1,
+                    17 => 1,
+                    19 => 1,
+                    20 => 1,
+                    21 => 1,
+                    23 => 1,
+                    24 => 1,
+                    25 => 1,
+                    61 => 1,
+                    62 => 1,
+                ];
         }
 
         return [
@@ -35,6 +60,7 @@ class UnusedUseStatementUnitTest extends AbstractTestCase
             19 => 1,
             20 => 1,
             21 => 1,
+            26 => 2,
             32 => 1,
             33 => 1,
             34 => 1,
@@ -46,6 +72,14 @@ class UnusedUseStatementUnitTest extends AbstractTestCase
             45 => 1,
             46 => 1,
             47 => 1,
+            54 => 2,
+            56 => 1,
+            58 => 1,
+            60 => 2,
+            61 => 1,
+            62 => 1,
+            63 => 1,
+            64 => 1,
         ];
     }
 


### PR DESCRIPTION
Adds support for use groups, various fixes on detecting if imported class/function/const is used in the code.

The same alias can be used for class, function and constant, so we need to detect what is the context of the string token.

For classes and function PHP is case insensitive, but not for constants. So we can have defined/imported constants with names: `FOO`, `Foo`, `foo` and all these three are different.