### PR TITLE
Hotfix: Namespaces\AlphabeticallySortedUses - sort uses also in files without namespace

### DIFF
--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.2.inc
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.2.inc
@@ -1,0 +1,31 @@
+<?php
+
+use const D;
+use const C;
+use B;
+use A;
+use function Y;
+use function X;
+use A\TagManager;
+use A\Tag;
+use A\Tag\Tags;
+use C\Response as MyResponse;
+use C\Response\HtmlResponse;
+
+class J {
+    use MyTrait;
+
+    public function closure($foo)
+    {
+        return function ($x) use ($foo) {
+            return $x <=> $foo;
+        };
+    }
+
+    public function anonym()
+    {
+        return new class() {
+            use AnotherTrait;
+        };
+    }
+}

--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.2.inc.fixed
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.2.inc.fixed
@@ -1,0 +1,33 @@
+<?php
+
+use A;
+use A\Tag;
+use A\Tag\Tags;
+use A\TagManager;
+use B;
+use C\Response as MyResponse;
+use C\Response\HtmlResponse;
+
+use function X;
+use function Y;
+
+use const C;
+use const D;
+
+class J {
+    use MyTrait;
+
+    public function closure($foo)
+    {
+        return function ($x) use ($foo) {
+            return $x <=> $foo;
+        };
+    }
+
+    public function anonym()
+    {
+        return new class() {
+            use AnotherTrait;
+        };
+    }
+}

--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.php
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.php
@@ -15,6 +15,10 @@ class AlphabeticallySortedUsesUnitTest extends AbstractTestCase
                 return [
                     6 => 1,
                 ];
+            case 'AlphabeticallySortedUsesUnitTest.2.inc':
+                return [
+                    4 => 1,
+                ];
         }
 
         return [


### PR DESCRIPTION
Before this sniff worked only on files with namespaces.
We'd like to sort imports also in files without namespace defined.