### PR TITLE
Hotfix: adds missing modifiers in Annotation sniffs

### DIFF
--- a/src/WebimpressCodingStandard/Helper/AnnotationsTrait.php
+++ b/src/WebimpressCodingStandard/Helper/AnnotationsTrait.php
@@ -18,10 +18,12 @@ use const T_ABSTRACT;
 use const T_DOC_COMMENT_CLOSE_TAG;
 use const T_DOC_COMMENT_STRING;
 use const T_DOC_COMMENT_TAG;
+use const T_FINAL;
 use const T_PRIVATE;
 use const T_PROTECTED;
 use const T_PUBLIC;
 use const T_STATIC;
+use const T_VAR;
 use const T_WHITESPACE;
 
 /**
@@ -56,7 +58,9 @@ trait AnnotationsTrait
             T_PRIVATE,
             T_STATIC,
             T_ABSTRACT,
+            T_FINAL,
             T_WHITESPACE,
+            T_VAR,
         ];
 
         $tokens = $phpcsFile->getTokens();

--- a/test/Sniffs/Commenting/ClassAnnotationUnitTest.3.inc
+++ b/test/Sniffs/Commenting/ClassAnnotationUnitTest.3.inc
@@ -1,0 +1,8 @@
+<?php // @phpcs:set WebimpressCodingStandard.Commenting.ClassAnnotation allowedAnnotations[] Config
+
+/**
+ * @ORM\Table(name="table")
+ * @Config(key="value")
+ */
+final class FinalClassWithAnnotations {
+}

--- a/test/Sniffs/Commenting/ClassAnnotationUnitTest.php
+++ b/test/Sniffs/Commenting/ClassAnnotationUnitTest.php
@@ -19,6 +19,10 @@ class ClassAnnotationUnitTest extends AbstractTestCase
                     13 => 1,
                     44 => 1,
                 ];
+            case 'ClassAnnotationUnitTest.3.inc':
+                return [
+                    4 => 1,
+                ];
         }
 
         return [

--- a/test/Sniffs/Commenting/MethodAnnotationUnitTest.1.inc
+++ b/test/Sniffs/Commenting/MethodAnnotationUnitTest.1.inc
@@ -23,4 +23,13 @@ class MethodCommentWithAnyAnnotations
     public function bar() : void
     {
     }
+
+    /**
+     * @ORM\FinalMethod
+     * @Config(key="value")
+     */
+    final function finalMethod() : string
+    {
+        return __CLASS__;
+    }
 }

--- a/test/Sniffs/Commenting/MethodAnnotationUnitTest.2.inc
+++ b/test/Sniffs/Commenting/MethodAnnotationUnitTest.2.inc
@@ -24,4 +24,13 @@ class MethodCommentWithSpecifiedAnnotations
     {
         return mt_rand();
     }
+
+    /**
+     * @ORM\FinalMethod
+     * @Config(key="value")
+     */
+    final function finalMethod() : string
+    {
+        return __CLASS__;
+    }
 }

--- a/test/Sniffs/Commenting/MethodAnnotationUnitTest.inc
+++ b/test/Sniffs/Commenting/MethodAnnotationUnitTest.inc
@@ -29,6 +29,15 @@ abstract class MethodCommentWithoutAnnotations
     private static function baz() : void
     {
     }
+
+    /**
+     * @ORM\FinalMethod
+     * @Config(key="value")
+     */
+    final public function finalMethod()
+    {
+        return __CLASS__;
+    }
 }
 
 new class ()

--- a/test/Sniffs/Commenting/MethodAnnotationUnitTest.php
+++ b/test/Sniffs/Commenting/MethodAnnotationUnitTest.php
@@ -17,6 +17,7 @@ class MethodAnnotationUnitTest extends AbstractTestCase
                 return [
                     9 => 1,
                     19 => 1,
+                    30 => 1,
                 ];
         }
 
@@ -25,6 +26,8 @@ class MethodAnnotationUnitTest extends AbstractTestCase
             9 => 1,
             18 => 1,
             27 => 1,
+            34 => 1,
+            35 => 1,
         ];
     }
 

--- a/test/Sniffs/Commenting/PropertyAnnotationUnitTest.1.inc
+++ b/test/Sniffs/Commenting/PropertyAnnotationUnitTest.1.inc
@@ -18,4 +18,11 @@ class PropertyCommentWithAnyAnnotations
      * })
      */
     public $bar;
+
+    /**
+     * @var bool
+     * @ORM\Boolean
+     * @Config(key="value")
+     */
+    var $var;
 }

--- a/test/Sniffs/Commenting/PropertyAnnotationUnitTest.2.inc
+++ b/test/Sniffs/Commenting/PropertyAnnotationUnitTest.2.inc
@@ -19,4 +19,11 @@ class PropertyCommentWithSpecifiedAnnotations
      * )
      */
     public $bar;
+
+    /**
+     * @var bool
+     * @ORM\Boolean
+     * @Config(key="value")
+     */
+    var $var;
 }

--- a/test/Sniffs/Commenting/PropertyAnnotationUnitTest.inc
+++ b/test/Sniffs/Commenting/PropertyAnnotationUnitTest.inc
@@ -21,6 +21,13 @@ class PropertyCommentWithoutAnnotations
 
     /**
      * @var bool
+     * @ORM\Boolean
+     * @Config(key="value")
+     */
+    var $var;
+
+    /**
+     * @var bool
      * @ORM\Column(@ORM\Value({"var", "bar", "baz"}))
      */
     private $baz;

--- a/test/Sniffs/Commenting/PropertyAnnotationUnitTest.php
+++ b/test/Sniffs/Commenting/PropertyAnnotationUnitTest.php
@@ -17,6 +17,7 @@ class PropertyAnnotationUnitTest extends AbstractTestCase
                 return [
                     9 => 1,
                     17 => 1,
+                    26 => 1,
                 ];
         }
 
@@ -25,6 +26,8 @@ class PropertyAnnotationUnitTest extends AbstractTestCase
             9 => 1,
             15 => 1,
             24 => 1,
+            25 => 1,
+            31 => 1,
         ];
     }
 


### PR DESCRIPTION
- `Commenting\ClassAnnotation` sniff - `final` classes.
- `Commenting\MethodAnootation` sniff - `final` methods.
- `Commenting\PropertyAnnotation` sniff - properties defined with `var`.