### PR TITLE
Hotfix: parsing `@param` and `@var` PHPDoc tags with multiple spaces

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Commenting/TagWithTypeSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Commenting/TagWithTypeSniff.php
@@ -190,7 +190,7 @@ class TagWithTypeSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        $split = preg_split('/\s/', $tokens[$tagPtr + 2]['content'], 3);
+        $split = preg_split('/\s+/', $tokens[$tagPtr + 2]['content'], 3);
 
         if (! isset($split[1])) {
             if ($this->isVariable($split[0])) {
@@ -238,7 +238,7 @@ class TagWithTypeSniff implements Sniff
         $condition = end($tokens[$tagPtr]['conditions']);
         $isMemberVar = isset(Tokens::$ooScopeTokens[$condition]);
 
-        $split = preg_split('/\s/', $tokens[$tagPtr + 2]['content'], 3);
+        $split = preg_split('/\s+/', $tokens[$tagPtr + 2]['content'], 3);
         if ($nested > 0 || ! $isMemberVar) {
             if (! isset($split[1])) {
                 if ($this->isVariable($split[0])) {

--- a/src/WebimpressCodingStandard/Sniffs/Functions/ParamSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Functions/ParamSniff.php
@@ -98,7 +98,7 @@ class ParamSniff implements Sniff
                 continue;
             }
 
-            $split = preg_split('/\s/', $tokens[$tag + 2]['content'], 3);
+            $split = preg_split('/\s+/', $tokens[$tag + 2]['content'], 3);
             if (! isset($split[1]) || ! $this->isVariable($split[1])) {
                 // Missing param type or it's not a variable
                 continue;

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.1.inc
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.1.inc
@@ -331,4 +331,11 @@ interface MyInterface extends MyOne, MyTwo
      * @param null|mixed[] $mixedArray
      */
     public function method5($mixed, array $mixedArray = null);
+
+    /**
+     * @param     int        $p1  Description
+     * @return    iterable        Description
+     * @throws    Exception       Description
+     */
+    public function moreThanOneSpace(int $p1) : iterable;
 }

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.1.inc.fixed
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.1.inc.fixed
@@ -331,4 +331,11 @@ interface MyInterface extends MyOne, MyTwo
      * @param null|mixed[] $mixedArray
      */
     public function method5($mixed, array $mixedArray = null);
+
+    /**
+     * @param     int        $p1  Description
+     * @return    iterable        Description
+     * @throws    Exception       Description
+     */
+    public function moreThanOneSpace(int $p1) : iterable;
 }

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc
@@ -304,4 +304,9 @@ class VarTag extends VarTagParent {
      * @var \RuntimeException\Hello Description.
      */
     public $a;
+
+    /**
+     * @var    int    $moreThanOneSpace   Some  long  description
+     */
+    public $moreThanOneSpace;
 }

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc.fixed
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.3.inc.fixed
@@ -304,4 +304,9 @@ class VarTag extends VarTagParent {
      * @var Exception\Hello Description.
      */
     public $a;
+
+    /**
+     * @var    int Some  long  description
+     */
+    public $moreThanOneSpace;
 }

--- a/test/Sniffs/Commenting/TagWithTypeUnitTest.php
+++ b/test/Sniffs/Commenting/TagWithTypeUnitTest.php
@@ -181,6 +181,7 @@ class TagWithTypeUnitTest extends AbstractTestCase
                     295 => 1,
                     299 => 1,
                     304 => 1,
+                    309 => 1,
                 ];
         }
 

--- a/test/Sniffs/Functions/ParamUnitTest.inc
+++ b/test/Sniffs/Functions/ParamUnitTest.inc
@@ -346,4 +346,9 @@ interface MyInterface extends MyOne, MyTwo
         ?iterable $i2,
         ?iterable $i3
     ) : void;
+
+    /**
+     * @param   int     $p1
+     */
+    public function moreThanOneSpace(int $p1) : void;
 }

--- a/test/Sniffs/Functions/ParamUnitTest.inc.fixed
+++ b/test/Sniffs/Functions/ParamUnitTest.inc.fixed
@@ -346,4 +346,9 @@ interface MyInterface extends MyOne, MyTwo
         ?iterable $i2,
         ?iterable $i3
     ) : void;
+
+    /**
+     *
+     */
+    public function moreThanOneSpace(int $p1) : void;
 }

--- a/test/Sniffs/Functions/ParamUnitTest.php
+++ b/test/Sniffs/Functions/ParamUnitTest.php
@@ -103,6 +103,7 @@ class ParamUnitTest extends AbstractTestCase
             334 => 1,
             335 => 1,
             336 => 1,
+            351 => 1,
         ];
     }
 

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.1.inc
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.1.inc
@@ -381,4 +381,9 @@ interface MyInterface extends MyOne, MyTwo
      * @return null|Foo|object Description
      */
     public function typeSpecifiedWithDescriptionObject() : ?object;
+
+    /**
+     * @return      null|int
+     */
+    public function moreThanOneSpace() : ?int;
 }

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.1.inc.fixed
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.1.inc.fixed
@@ -381,4 +381,9 @@ interface MyInterface extends MyOne, MyTwo
      * @return null|Foo Description
      */
     public function typeSpecifiedWithDescriptionObject() : ?object;
+
+    /**
+     *
+     */
+    public function moreThanOneSpace() : ?int;
 }

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.php
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.php
@@ -80,6 +80,7 @@ class ReturnTypeUnitTest extends AbstractTestCase
                     371 => 1,
                     376 => 1,
                     381 => 1,
+                    386 => 1,
                 ];
             case 'ReturnTypeUnitTest.2.inc':
                 return [

--- a/test/Sniffs/Functions/ThrowsUnitTest.inc
+++ b/test/Sniffs/Functions/ThrowsUnitTest.inc
@@ -310,4 +310,12 @@ class ThrowUnitTest
             throw new Exception();
         });
     }
+
+    /**
+     * @throws    Exception    Description
+     */
+    public function moreThanOneSpace()
+    {
+        throw new Exception();
+    }
 }

--- a/test/Sniffs/Functions/ThrowsUnitTest.inc.fixed
+++ b/test/Sniffs/Functions/ThrowsUnitTest.inc.fixed
@@ -310,4 +310,12 @@ class ThrowUnitTest
             throw new Exception();
         });
     }
+
+    /**
+     * @throws    Exception    Description
+     */
+    public function moreThanOneSpace()
+    {
+        throw new Exception();
+    }
 }


### PR DESCRIPTION
Split on string was done incorrectly, as it assumed always one white character, where we can have multiple spaces (in case variable names are aligned in PHPDocs).

Fixed how we split the string, so we can get better results on reporting errors and fixing.