### PR TITLE
Feature: Classes\TraitUsage - checks if traits are defined on top of the class

### DIFF
--- a/test/Sniffs/Classes/TraitUsageUnitTest.inc
+++ b/test/Sniffs/Classes/TraitUsageUnitTest.inc
@@ -39,3 +39,18 @@ class Foo
         $closure = function () use ($x) {};
     }
 }
+
+class TraitsOnTop
+{
+    /** @var int */
+    var $prop1 = 1;
+    const CONST_1 = 1;
+    use Trait1;
+    // This is a comment
+    use Trait2 {
+        m1 as m2;
+        m3 insteadof m3;
+    }
+    static protected int $var = 'value';
+    use \MyNamespace\Trait3, Trait4;
+}

--- a/test/Sniffs/Classes/TraitUsageUnitTest.inc.fixed
+++ b/test/Sniffs/Classes/TraitUsageUnitTest.inc.fixed
@@ -43,3 +43,20 @@ use ATrait;
         $closure = function () use ($x) {};
     }
 }
+
+class TraitsOnTop
+{
+    use Trait1;
+    // This is a comment
+    use Trait2 {
+        m1 as m2;
+        m3 insteadof m3;
+    }
+    use \MyNamespace\Trait3;
+use Trait4;
+
+    /** @var int */
+    var $prop1 = 1;
+    const CONST_1 = 1;
+    static protected int $var = 'value';
+}

--- a/test/Sniffs/Classes/TraitUsageUnitTest.php
+++ b/test/Sniffs/Classes/TraitUsageUnitTest.php
@@ -22,6 +22,9 @@ class TraitUsageUnitTest extends AbstractTestCase
             26 => 3,
             27 => 2,
             36 => 1,
+            48 => 1,
+            50 => 1,
+            55 => 1,
         ];
     }
 


### PR DESCRIPTION
We cannot have any other properties, constants, methods... defined before traits in classes/traits.