### PR TITLE
Feature: WhiteSpace\OperatorAndKeywordSpacing sniff

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/WhiteSpace/OperatorAndKeywordSpacingSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/WhiteSpace/OperatorAndKeywordSpacingSniff.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandard\Sniffs\WhiteSpace;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+use function in_array;
+
+use const T_AS;
+use const T_INSTANCEOF;
+use const T_INSTEADOF;
+use const T_WHITESPACE;
+
+class OperatorAndKeywordSpacingSniff extends OperatorSpacingSniff
+{
+    /** @var bool Override default value from parent sniff */
+    public $ignoreNewlines = true;
+
+    /** @var bool Override default value from parent sniff */
+    public $ignoreSpacingBeforeAssignments = false;
+
+    /** @var int[] */
+    private $doNotIgnoreNewLineForTokens = [
+        T_INSTEADOF,
+        T_INSTANCEOF,
+        T_AS,
+    ];
+
+    public function register() : array
+    {
+        $tokens = parent::register();
+        $tokens += Tokens::$booleanOperators;
+        $tokens[] = T_AS;
+        $tokens[] = T_INSTEADOF;
+
+        return $tokens;
+    }
+
+    /**
+     * @param int $stackPtr
+     */
+    public function process(File $phpcsFile, $stackPtr) : void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $originalValue = $this->ignoreNewlines;
+        if (in_array($tokens[$stackPtr]['code'], $this->doNotIgnoreNewLineForTokens, true)) {
+            $this->ignoreNewlines = false;
+        }
+
+        parent::process($phpcsFile, $stackPtr);
+
+        if ($this->ignoreNewlines === true) {
+            if (isset($tokens[$stackPtr + 2])
+                && $tokens[$stackPtr + 1]['code'] === T_WHITESPACE
+                && $tokens[$stackPtr + 2]['line'] !== $tokens[$stackPtr]['line']
+            ) {
+                $error = 'Expected 1 space after "%s"; newline found';
+                $data = [$tokens[$stackPtr]['content']];
+
+                $fix = $phpcsFile->addFixableError($error, $stackPtr, 'SpacingAfter', $data);
+                if ($fix) {
+                    $phpcsFile->fixer->beginChangeset();
+                    $j = $stackPtr - 1;
+                    while ($tokens[$j]['code'] === T_WHITESPACE) {
+                        $phpcsFile->fixer->replaceToken($j, '');
+                        --$j;
+                    }
+                    $next = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true);
+                    $phpcsFile->fixer->replaceToken($stackPtr, '');
+                    $phpcsFile->fixer->addContentBefore($next, $tokens[$stackPtr]['content'] . ' ');
+                    $phpcsFile->fixer->endChangeset();
+                }
+            }
+
+            $prev = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, null, true);
+            if ($tokens[$prev]['line'] + 1 < $tokens[$stackPtr]['line']) {
+                $j = $stackPtr - 1;
+                while ($tokens[$j]['line'] === $tokens[$stackPtr]['line']) {
+                    --$j;
+                }
+
+                $error = 'Empty line is not allowed here';
+                $fix = $phpcsFile->addFixableError($error, $j, 'EmptyLine');
+
+                if ($fix) {
+                    $phpcsFile->fixer->replaceToken($j, '');
+                }
+            }
+        }
+
+        $this->ignoreNewlines = $originalValue;
+    }
+}

--- a/src/WebimpressCodingStandard/ruleset.xml
+++ b/src/WebimpressCodingStandard/ruleset.xml
@@ -116,11 +116,6 @@
             <property name="ignoreNewlines" value="true"/>
         </properties>
     </rule>
-    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
-        <properties>
-            <property name="ignoreNewlines" value="true"/>
-        </properties>
-    </rule>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>

--- a/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc
+++ b/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc
@@ -1,0 +1,36 @@
+<?php
+
+$c
+=
+    $a
+    +
+    $b;
+
+class MyClass {
+    use Trait1 {
+        m1  as  m2;
+        m3  insteadof  m4;
+    }
+}
+
+$a
+    instanceof
+Exception;
+
+if ($a
+&&
+$b) {
+    $a =
+        $b;
+}
+
+$a &&
+$b;
+
+$a = $b
+
+    && $c;
+
+$a = $b // comment
+
+    && $c;

--- a/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc.fixed
+++ b/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc.fixed
@@ -1,0 +1,29 @@
+<?php
+
+$c
+    = $a
+    + $b;
+
+class MyClass {
+    use Trait1 {
+        m1 as m2;
+        m3 insteadof m4;
+    }
+}
+
+$a instanceof Exception;
+
+if ($a
+&& $b) {
+    $a
+        = $b;
+}
+
+$a
+&& $b;
+
+$a = $b
+    && $c;
+
+$a = $b // comment
+    && $c;

--- a/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.php
+++ b/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandardTest\Sniffs\WhiteSpace;
+
+use WebimpressCodingStandardTest\Sniffs\AbstractTestCase;
+
+class OperatorAndKeywordSpacingUnitTest extends AbstractTestCase
+{
+    protected function getErrorList(string $testFile = '') : array
+    {
+        return [
+            4 => 1,
+            6 => 1,
+            11 => 2,
+            12 => 2,
+            17 => 2,
+            21 => 1,
+            23 => 1,
+            27 => 1,
+            31 => 1,
+            35 => 1,
+        ];
+    }
+
+    protected function getWarningList(string $testFile = '') : array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Replaces `Squiz.WhiteSpace.OperatorSpacing` as it was not possible to
configure to force space after (and before) some tokens only.

It still extends `Squiz.WhiteSpace.OperatorSpacing` but works also with
some PHP keywords (`as`, `insteadof`) and force one space before and after:
- `as`
- `insteadof`
- `instanceof`

Also, this new sniff allow only ONE empty line before operator,
and disallow empty line after opertator.
In case operator is at the end of the line it will be moved to next line
just before the non-empty content with single space.