### PR TITLE
Add Iterator type support + fixes for functions with yield

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Functions/ParamSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Functions/ParamSniff.php
@@ -331,6 +331,7 @@ class ParamSniff implements Sniff
             'iterable' => ['iterable'],
             'traversable' => ['traversable', '\traversable'],
             'generator' => ['generator', '\generator'],
+            'iterator' => ['iterator', '\iterator'],
             'object' => ['object'],
         ];
         // @phpcs:enable
@@ -444,7 +445,7 @@ class ParamSniff implements Sniff
                         '?\generator',
                     ], true)
                     && ! in_array($lower, ['generator', '\generator'], true)
-                    && in_array($lower, array_merge($simpleTypes, ['mixed']), true)
+                    && in_array($lower, $simpleTypes, true)
                 ) {
                     $error = 'Param type contains %s which is not a generator type';
                     $data = [
@@ -456,10 +457,30 @@ class ParamSniff implements Sniff
                     continue;
                 }
 
+                // iterator
+                if (in_array($lowerTypeHint, [
+                        'iterator',
+                        '?iterator',
+                        '\iterator',
+                        '?\iterator',
+                    ], true)
+                    && ! in_array($lower, ['iterator', '\iterator'], true)
+                    && in_array($lower, $simpleTypes, true)
+                ) {
+                    $error = 'Param type contains %s which is not an Iterator type';
+                    $data = [
+                        $type,
+                    ];
+                    $phpcsFile->addError($error, $tagPtr + 2, 'NotIteratorType', $data);
+
+                    $break = true;
+                    continue;
+                }
+
                 // object
                 if (in_array($lowerTypeHint, ['object', '?object'], true)
                     && $lower !== 'object'
-                    && (in_array($lower, array_merge($simpleTypes, ['mixed']), true)
+                    && (in_array($lower, $simpleTypes, true)
                         || strpos($type, '[]') !== false)
                 ) {
                     $error = 'Param type contains %s which is not an object type';
@@ -485,6 +506,10 @@ class ParamSniff implements Sniff
                     '?generator',
                     '\generator',
                     '?\generator',
+                    'iterator',
+                    '?iterator',
+                    '\iterator',
+                    '?\iterator',
                     'object',
                     '?object',
                 ];

--- a/test/Sniffs/Functions/ParamUnitTest.1.inc
+++ b/test/Sniffs/Functions/ParamUnitTest.1.inc
@@ -196,4 +196,9 @@ class FunctionParam
         object $static,
         object $parent
     ) : void;
+
+    /**
+     * @param int|array|string|bool[]|float[]|MyIterator|\Iterator $iterator
+     */
+    abstract protected function nonIteratorTypes(\Iterator $iterator) : void;
 }

--- a/test/Sniffs/Functions/ParamUnitTest.php
+++ b/test/Sniffs/Functions/ParamUnitTest.php
@@ -30,6 +30,7 @@ class ParamUnitTest extends AbstractTestCase
                     143 => 2,
                     154 => 1,
                     159 => 1,
+                    201 => 4,
                 ];
         }
 

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.2.inc
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.2.inc
@@ -471,4 +471,17 @@ abstract class FunctionCommentReturn
     {
         return $this;
     }
+
+    /**
+     * @return int[]|float[]|string|array|bool|MyClass|MyIterator|\Iterator
+     */
+    public function generatorIterator() : \Iterator
+    {
+        yield 1;
+        yield 1.2;
+        yield 'string';
+        yield [];
+        yield true;
+        yield null;
+    }
 }

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.2.inc.fixed
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.2.inc.fixed
@@ -471,4 +471,17 @@ abstract class FunctionCommentReturn
     {
         return $this;
     }
+
+    /**
+     * @return int[]|float[]|string|array|bool|MyClass|MyIterator
+     */
+    public function generatorIterator() : \Iterator
+    {
+        yield 1;
+        yield 1.2;
+        yield 'string';
+        yield [];
+        yield true;
+        yield null;
+    }
 }

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.3.inc
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.3.inc
@@ -2,6 +2,8 @@
 
 namespace MyNamespace\Test\Functions;
 
+use Iterator as IteratorAlias;
+
 class FunctionCommentReturn
 {
     /**
@@ -181,5 +183,55 @@ class FunctionCommentReturn
     public function test() : array
     {
         return [];
+    }
+
+    public function generator1() : iterable
+    {
+        yield 1;
+        yield 1.2;
+        yield 'string';
+        yield [];
+        yield true;
+        yield null;
+    }
+
+    public function generator2() : \Generator
+    {
+        yield 1;
+        yield 1.2;
+        yield 'string';
+        yield [];
+        yield true;
+        yield null;
+    }
+
+    public function generator3() : \Traversable
+    {
+        yield 1;
+        yield 1.2;
+        yield 'string';
+        yield [];
+        yield true;
+        yield null;
+    }
+
+    public function generator4() : IteratorAlias
+    {
+        yield 1;
+        yield 1.2;
+        yield 'string';
+        yield [];
+        yield true;
+        yield null;
+    }
+
+    public function generator5() : MyCustomGenerator
+    {
+        yield 1;
+        yield 1.2;
+        yield 'string';
+        yield [];
+        yield true;
+        yield null;
     }
 }

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.php
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.php
@@ -153,19 +153,21 @@ class ReturnTypeUnitTest extends AbstractTestCase
                     452 => 1,
                     460 => 1,
                     468 => 1,
+                    476 => 4,
                 ];
             case 'ReturnTypeUnitTest.3.inc':
                 return [
-                    8 => 1,
-                    24 => 1,
-                    40 => 1,
-                    56 => 1,
-                    72 => 1,
-                    96 => 1,
-                    120 => 1,
-                    144 => 1,
-                    160 => 1,
-                    168 => 1,
+                    10 => 1,
+                    26 => 1,
+                    42 => 1,
+                    58 => 1,
+                    74 => 1,
+                    98 => 1,
+                    122 => 1,
+                    146 => 1,
+                    162 => 1,
+                    170 => 1,
+                    228 => 1,
                 ];
         }
 
@@ -180,6 +182,8 @@ class ReturnTypeUnitTest extends AbstractTestCase
             36 => 1,
             41 => 1,
             46 => 1,
+            54 => 1,
+            59 => 1,
             95 => 1,
             99 => 1,
             108 => 1,


### PR DESCRIPTION
Generators (functions with yield) can have only:
`Generator`, `Iterator`, `Traversable` or `iterable` return type hint.

Add support for Iterator type in `Functions\Param` and `Functions\ReturnType` sniffs.