### PR TITLE
Feature: ability to align array arrows when in new line

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -39,6 +39,7 @@ use const T_COMMENT;
 use const T_CONSTANT_ENCAPSED_STRING;
 use const T_CONTINUE;
 use const T_DOC_COMMENT_OPEN_TAG;
+use const T_DOUBLE_ARROW;
 use const T_DOUBLE_QUOTED_STRING;
 use const T_ECHO;
 use const T_ELSEIF;
@@ -86,6 +87,15 @@ class ScopeIndentSniff implements Sniff
      * @var bool
      */
     public $alignObjectOperators = true;
+
+    /**
+     * Ignore alignment of array arrows which are at the beginning of new line.
+     * If set to true, other sniff should check alignment of these arrows
+     * - for example WebimpressCodingStandard.Arrays.DoubleArrow
+     *
+     * @var bool
+     */
+    public $ignoreNewLineArrayArrow = false;
 
     /**
      * @var int[]
@@ -740,6 +750,8 @@ class ScopeIndentSniff implements Sniff
                             $expectedIndent += $this->indent;
                         }
                     }
+                } elseif ($this->ignoreNewLineArrayArrow && $tokens[$next]['code'] === T_DOUBLE_ARROW) {
+                    continue;
                 }
 
                 $expectedIndent += $extraIndent;

--- a/test/Integration/AlignOperators.php
+++ b/test/Integration/AlignOperators.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+$array = [
+'key' => 'value',
+'k'
+=> 'value',
+'k1' => 'value',
+];

--- a/test/Integration/AlignOperators.php.fixed
+++ b/test/Integration/AlignOperators.php.fixed
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+$array = [
+    'key' => 'value',
+    'k'
+          => 'value',
+    'k1'  => 'value',
+];

--- a/test/Integration/AlignOperators.xml
+++ b/test/Integration/AlignOperators.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="Webimpress Coding Standard">
+    <rule ref="../../src/WebimpressCodingStandard/ruleset.xml"/>
+
+    <rule ref="WebimpressCodingStandard.Arrays.DoubleArrow">
+        <properties>
+            <property name="maxPadding" value="30"/>
+            <property name="ignoreNewLineArrayArrow" value="false"/>
+        </properties>
+    </rule>
+
+    <rule ref="WebimpressCodingStandard.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="ignoreNewLineArrayArrow" value="true"/>
+        </properties>
+    </rule>
+
+    <rule ref="WebimpressCodingStandard.WhiteSpace.OperatorAndKeywordSpacing">
+        <properties>
+            <property name="ignoreSpacingBeforeAssignments" value="true"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -10,8 +10,10 @@ use PHPUnit\Framework\TestCase;
 use function basename;
 use function copy;
 use function exec;
+use function file_exists;
 use function glob;
 use function implode;
+use function str_replace;
 use function sys_get_temp_dir;
 use function tempnam;
 
@@ -25,7 +27,10 @@ class IntegrationTest extends TestCase
         $tmpname = tempnam(sys_get_temp_dir(), '') . '_' . basename($file);
         copy($file, $tmpname);
 
-        exec('vendor/bin/phpcbf ' . $tmpname, $output, $returnVal);
+        $rulesetFile = str_replace('.php', '.xml', $file);
+        $options = file_exists($rulesetFile) ? ' --standard=' . $rulesetFile : '';
+
+        exec('vendor/bin/phpcbf ' . $tmpname . $options, $output, $returnVal);
 
         self::assertSame(1, $returnVal, 'Output: ' . "\n" . implode("\n", $output));
         self::assertFileEquals($file . '.fixed', $tmpname);

--- a/test/Sniffs/Arrays/DoubleArrowUnitTest.1.inc.fixed
+++ b/test/Sniffs/Arrays/DoubleArrowUnitTest.1.inc.fixed
@@ -1,7 +1,7 @@
 <?php
 // @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow maxPadding 30
 
-$s = ['a' => 'b', 'c'=>'d'];
+$s = ['a' => 'b', 'c' =>'d'];
 $m = [
     'a'
         => 'b',

--- a/test/Sniffs/Arrays/DoubleArrowUnitTest.2.inc
+++ b/test/Sniffs/Arrays/DoubleArrowUnitTest.2.inc
@@ -1,0 +1,33 @@
+<?php
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow maxPadding 30
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow ignoreNewLineArrayArrow false
+
+$m = [
+    'foo' => 'bar',
+    'very-long-key'
+    => 'value',
+    'foo-bar' => 'baz',
+];
+
+$x = [
+    '1' => 1,
+    '1_____' => 1,
+    '1__' => 1,
+    '2_____________________________________________________' => 2,
+    '3' => 3,
+    '3____' => 3,
+    '3_' => 3,
+    '3_______' => 3,
+    '3____________________' => 3,
+    '3___'
+    => 'value in new line does not break aligning group',
+    '3__' => 3,
+    '3_____' => 3,
+    'value without index breaks aligning group',
+    '4___' => 4,
+    '4' => 4,
+
+    '5_'   => 'empty line breaks alignment group',
+    // comment
+    '6_____' => 'comment breaks alignment group',
+];

--- a/test/Sniffs/Arrays/DoubleArrowUnitTest.2.inc.fixed
+++ b/test/Sniffs/Arrays/DoubleArrowUnitTest.2.inc.fixed
@@ -1,0 +1,33 @@
+<?php
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow maxPadding 30
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow ignoreNewLineArrayArrow false
+
+$m = [
+    'foo'     => 'bar',
+    'very-long-key'
+              => 'value',
+    'foo-bar' => 'baz',
+];
+
+$x = [
+    '1'      => 1,
+    '1_____' => 1,
+    '1__'    => 1,
+    '2_____________________________________________________' => 2,
+    '3'                     => 3,
+    '3____'                 => 3,
+    '3_'                    => 3,
+    '3_______'              => 3,
+    '3____________________' => 3,
+    '3___'
+                            => 'value in new line does not break aligning group',
+    '3__'                   => 3,
+    '3_____'                => 3,
+    'value without index breaks aligning group',
+    '4___' => 4,
+    '4'    => 4,
+
+    '5_' => 'empty line breaks alignment group',
+    // comment
+    '6_____' => 'comment breaks alignment group',
+];

--- a/test/Sniffs/Arrays/DoubleArrowUnitTest.inc
+++ b/test/Sniffs/Arrays/DoubleArrowUnitTest.inc
@@ -1,4 +1,6 @@
-<?php // @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow maxPadding 1
+<?php
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow maxPadding 1
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow ignoreNewLineArrayArrow true
 
 $s = ['a'    => 'b', 'c'=>'d'];
 $m = [

--- a/test/Sniffs/Arrays/DoubleArrowUnitTest.inc.fixed
+++ b/test/Sniffs/Arrays/DoubleArrowUnitTest.inc.fixed
@@ -1,6 +1,8 @@
-<?php // @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow maxPadding 1
+<?php
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow maxPadding 1
+// @phpcs:set WebimpressCodingStandard.Arrays.DoubleArrow ignoreNewLineArrayArrow true
 
-$s = ['a' => 'b', 'c'=>'d'];
+$s = ['a' => 'b', 'c' =>'d'];
 $m = [
     'a'
         => 'b',

--- a/test/Sniffs/Arrays/DoubleArrowUnitTest.php
+++ b/test/Sniffs/Arrays/DoubleArrowUnitTest.php
@@ -13,7 +13,7 @@ class DoubleArrowUnitTest extends AbstractTestCase
         switch ($testFile) {
             case 'DoubleArrowUnitTest.1.inc':
                 return [
-                    4 => 1,
+                    4 => 2,
                     6 => 1,
                     10 => 1,
                     14 => 1,
@@ -41,15 +41,31 @@ class DoubleArrowUnitTest extends AbstractTestCase
                     59 => 1,
                     61 => 1,
                 ];
+            case 'DoubleArrowUnitTest.2.inc':
+                return [
+                    6 => 1,
+                    8 => 1,
+                    13 => 1,
+                    15 => 1,
+                    17 => 1,
+                    18 => 1,
+                    19 => 1,
+                    20 => 1,
+                    23 => 1,
+                    24 => 1,
+                    25 => 1,
+                    28 => 1,
+                    30 => 1,
+                ];
         }
 
         return [
-            3 => 1,
-            5 => 1,
-            9 => 1,
-            13 => 1,
-            14 => 1,
+            5 => 2,
+            7 => 1,
+            11 => 1,
+            15 => 1,
             16 => 1,
+            18 => 1,
         ];
     }
 


### PR DESCRIPTION
To configure that we need to set (for example):

```
// configuration of double arrow alignment
WebimpressCodingStandard.Arrays.DoubleArrow.maxPadding = 50
WebimpressCodingStandard.Arrays.DoubleArrow.ignoreNewLineArrayArrow = false

// ignore indent or double arrow when at the beggining of the line
WebimpressCodingStandard.WhiteSpace.ScopeIndent.ignoreNewLineArrayArrow = true

// ignore spacing before double arrow (so we can have more than one space)
WebimpressCodingStandard.WhiteSpace.OperatorAndKeywordSpacing.ignoreSpacingBeforeAssignments = true
```

Fixes #29