### PR TITLE
Hotfix: Namespaces\AlphabeticallySortedUses do not remove content

### DIFF
--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc
@@ -43,3 +43,11 @@ namespace D {
     use Psr_Underscore;
     use PsrLetter;
 }
+
+namespace E {
+    use Foo;
+
+    class Bar {}
+
+    use Baz;
+}

--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc.fixed
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.inc.fixed
@@ -46,3 +46,11 @@ namespace D {
     use Psr_Underscore;
     use PsrLetter;
 }
+
+namespace E {
+    use Baz;
+use Foo;
+
+    class Bar {}
+
+}

--- a/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.php
+++ b/test/Sniffs/Namespaces/AlphabeticallySortedUsesUnitTest.php
@@ -29,6 +29,7 @@ class AlphabeticallySortedUsesUnitTest extends AbstractTestCase
             32 => 1,
             33 => 1,
             37 => 2,
+            52 => 1,
         ];
     }
 


### PR DESCRIPTION
If use statement is below some additional content (for example class
definition) it has been removed on sorting.