### PR TITLE
Hotfix: Namespaces\UnusedUseStatement false positive for multiple trait usages

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Namespaces/UnusedUseStatementSniff.php
@@ -417,15 +417,6 @@ class UnusedUseStatementSniff implements Sniff
             return 'class';
         }
 
-        // Trait usage
-        if ($beforeCode === T_USE) {
-            if (CodingStandard::isTraitUse($phpcsFile, $beforePtr)) {
-                return 'class';
-            }
-
-            return null;
-        }
-
         if ($beforeCode === T_COMMA) {
             $prev = $phpcsFile->findPrevious(
                 Tokens::$emptyTokens + [
@@ -441,6 +432,23 @@ class UnusedUseStatementSniff implements Sniff
             if ($tokens[$prev]['code'] === T_IMPLEMENTS || $tokens[$prev]['code'] === T_EXTENDS) {
                 return 'class';
             }
+
+            if ($tokens[$prev]['code'] === T_INSTEADOF) {
+                return null;
+            }
+
+            if ($tokens[$prev]['code'] === T_USE) {
+                $beforeCode = T_USE;
+            }
+        }
+
+        // Trait usage
+        if ($beforeCode === T_USE) {
+            if (CodingStandard::isTraitUse($phpcsFile, $beforePtr)) {
+                return 'class';
+            }
+
+            return null;
         }
 
         $afterPtr = $phpcsFile->findNext(Tokens::$emptyTokens, $ptr + 1, null, true);

--- a/test/Integration/TraitImportConflict.php
+++ b/test/Integration/TraitImportConflict.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasCodingStandardTest\fixed;
+
+use Vendor\Package\FirstTrait;
+use Vendor\Package\SecondTrait;
+use Vendor\Package\ThirdTrait;
+
+class TraitImportConflict
+{
+    use ThirdTrait;
+
+    use FirstTrait, SecondTrait;
+}

--- a/test/Integration/TraitImportConflict.php.fixed
+++ b/test/Integration/TraitImportConflict.php.fixed
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasCodingStandardTest\fixed;
+
+use Vendor\Package\FirstTrait;
+use Vendor\Package\SecondTrait;
+use Vendor\Package\ThirdTrait;
+
+class TraitImportConflict
+{
+    use FirstTrait;
+    use SecondTrait;
+    use ThirdTrait;
+}

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc
@@ -62,6 +62,7 @@ use FooBar\{Used33};
 use FooBar\{Used34,}; // PHP 7.2+
 use FooBar\{Unused23};
 use EmptyGroup\{};
+use UsedTrait;
 
 /**
  * @method Used23 myMethod(Used24 $param1, Used25 $param2)
@@ -77,7 +78,7 @@ class Foo
 {
     use Traits\MyTrait;
     use Traits\Used1;
-    use Used17;
+    use Used17, UsedTrait;
 
     private $unused2;
 

--- a/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
+++ b/test/Sniffs/Namespaces/UnusedUseStatementUnitTest.inc.fixed
@@ -37,6 +37,7 @@ use MyApp\OtherNamespace\Used30 as AliasUsed30;
 use Abc\Used31, Ghi\Used32;
 use FooBar\Used33;
 use FooBar\Used34; // PHP 7.2+
+use UsedTrait;
 
 /**
  * @method Used23 myMethod(Used24 $param1, Used25 $param2)
@@ -52,7 +53,7 @@ class Foo
 {
     use Traits\MyTrait;
     use Traits\Used1;
-    use Used17;
+    use Used17, UsedTrait;
 
     private $unused2;
 


### PR DESCRIPTION
Import statement was removed in case of multiple trait usage.

Fixes #73

/cc @geerteltink 