### PR TITLE
Hotfix: allow null value for properties with nullable type declaration

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Classes/NoNullValuesSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Classes/NoNullValuesSniff.php
@@ -30,8 +30,20 @@ class NoNullValuesSniff extends AbstractVariableSniff
 
         $value = $phpcsFile->findNext(Tokens::$emptyTokens, $next + 1, null, true);
         if ($tokens[$value]['code'] === T_NULL) {
-            $error = 'Default null value for the property is redundant';
-            $fix = $phpcsFile->addFixableError($error, $value, 'NullValue');
+            $props = $phpcsFile->getMemberProperties($stackPtr);
+            if ($props['type'] !== '' && $props['nullable_type'] === true) {
+                return;
+            }
+
+            $error = $props['type'] !== '' && $props['nullable_type'] === false
+                ? 'Default null value for not-nullable property is invalid'
+                : 'Default null value for the property is redundant';
+
+            $code = $props['type'] !== '' && $props['nullable_type'] === false
+                ? 'Invalid'
+                : 'NullValue';
+
+            $fix = $phpcsFile->addFixableError($error, $value, $code);
 
             if ($fix) {
                 $phpcsFile->fixer->beginChangeset();

--- a/test/Sniffs/Classes/NoNullValuesUnitTest.inc
+++ b/test/Sniffs/Classes/NoNullValuesUnitTest.inc
@@ -12,6 +12,9 @@ class NoNullValues
 
     public $v5 = /* comment */ null;
 
+    public ?\DateTime $d1 = null;
+    public \DateTime $d2 = null;
+
     /**
      * @param mixed $x
      */

--- a/test/Sniffs/Classes/NoNullValuesUnitTest.inc.fixed
+++ b/test/Sniffs/Classes/NoNullValuesUnitTest.inc.fixed
@@ -11,6 +11,9 @@ class NoNullValues
 
     public $v5/* comment */;
 
+    public ?\DateTime $d1 = null;
+    public \DateTime $d2;
+
     /**
      * @param mixed $x
      */

--- a/test/Sniffs/Classes/NoNullValuesUnitTest.php
+++ b/test/Sniffs/Classes/NoNullValuesUnitTest.php
@@ -16,7 +16,8 @@ class NoNullValuesUnitTest extends AbstractTestCase
             9 => 1,
             11 => 1,
             13 => 1,
-            23 => 1,
+            16 => 1,
+            26 => 1,
         ];
     }
 

--- a/test/Sniffs/Commenting/PropertyAnnotationUnitTest.1.inc
+++ b/test/Sniffs/Commenting/PropertyAnnotationUnitTest.1.inc
@@ -34,8 +34,8 @@ class PropertyCommentWithAnyAnnotations
     private ?\DateTime $typed;
 
     /**
-     * @ORM\CallbackFunction
+     * @ORM\IntType
      * @Config(require="PHP 7.4")
      */
-    private callable $callback;
+    private int $int;
 }

--- a/test/Sniffs/Commenting/PropertyAnnotationUnitTest.2.inc
+++ b/test/Sniffs/Commenting/PropertyAnnotationUnitTest.2.inc
@@ -35,8 +35,8 @@ class PropertyCommentWithSpecifiedAnnotations
     private ?\DateTime $typed;
 
     /**
-     * @ORM\CallbackFunction
+     * @ORM\IntType
      * @Config(require="PHP 7.4")
      */
-    private callable $callback;
+    private int $int;
 }


### PR DESCRIPTION
Since PHP 7.4 we can define property type. In that case, when property
is defined with nullable type we can have default null value, as it is
different from not being initialised.

Removed also invalid test case with callable property type, as it is not
valid in PHP 7.4.

Fixes #72

Also adds new code type for null values for properties with not-nullable
type declaration. This is technically invalid code.

/cc @shandyDev 