### PR TITLE
Hotfix: PHP\DisallowFqn when namespace is already in use

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/PHP/DisallowFqnSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/PHP/DisallowFqnSniff.php
@@ -426,8 +426,11 @@ class DisallowFqnSniff implements Sniff
 
                 $fix = $phpcsFile->addFixableError($error, $stackPtr, 'NamespaceImported', $data);
                 if ($fix) {
+                    $additional = substr($name, strlen($class['fqn']) + 1);
+                    $expected = $class['name'] . ($additional ? '\\' . $additional : '');
+
                     $phpcsFile->fixer->beginChangeset();
-                    $this->fixError($phpcsFile, $stackPtr, $class['name']);
+                    $this->fixError($phpcsFile, $stackPtr, $expected);
                     $phpcsFile->fixer->endChangeset();
                 }
 

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.inc
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.inc
@@ -172,4 +172,11 @@ class TheClass extends \ MyNamespace \ Hello \ ParentClass implements \ArrayAcce
     {
         return $obj;
     }
+
+    public function method2()
+    {
+        new \MyNamespace\Foo1\Bar1();
+        new \MyNamespace\Foo1\Bar1\Bar2();
+        new \Foo\BarBaz\Bar3();
+    }
 }

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.inc.fixed
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.inc.fixed
@@ -28,6 +28,7 @@ use MyTrait;
 use B;
 use InFnClosure\Param1;
 use InFnClosure\ReturnType1;
+use MyNamespace\Foo1\Bar1;
 
 use \ArrayObject as AO;
 use Foo\BarBaz;
@@ -198,5 +199,12 @@ class TheClass extends ParentClass      implements ArrayAccess, Countable
     public function method2($obj)
     {
         return $obj;
+    }
+
+    public function method2()
+    {
+        new Bar1();
+        new Bar1\Bar2();
+        new BarBaz\Bar3();
     }
 }

--- a/test/Sniffs/PHP/DisallowFqnUnitTest.php
+++ b/test/Sniffs/PHP/DisallowFqnUnitTest.php
@@ -100,6 +100,9 @@ class DisallowFqnUnitTest extends AbstractTestCase
             157 => 2,
             161 => 1,
             169 => 1,
+            178 => 1,
+            179 => 1,
+            180 => 1,
         ];
     }
 


### PR DESCRIPTION
Failing case:

```php
namespace A;

use B;

new B();
new \B\C();
```

Expected result:

```php
namespace A;

use B;

new B();
new B\C();
```

Actual result:

```php
namespace A;

use B;

new B();
new B();
```