### PR TITLE
Fixes importing class constant with global constant names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#121](https://github.com/webimpress/coding-standard/pull/121) fixes false-positive on importing class constant with global constant names - `PHP\ImportInternalConstant`.
 
 ## 1.1.5 - 2020-04-06
 

--- a/src/WebimpressCodingStandard/Sniffs/PHP/ImportInternalConstantSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/PHP/ImportInternalConstantSniff.php
@@ -14,6 +14,7 @@ use function sort;
 use function sprintf;
 use function strtoupper;
 
+use const T_CONST;
 use const T_DOUBLE_COLON;
 use const T_FUNCTION;
 use const T_NAMESPACE;
@@ -145,6 +146,7 @@ class ImportInternalConstantSniff implements Sniff
             || $tokens[$prev]['code'] === T_STRING
             || $tokens[$prev]['code'] === T_DOUBLE_COLON
             || $tokens[$prev]['code'] === T_OBJECT_OPERATOR
+            || $tokens[$prev]['code'] === T_CONST
         ) {
             return null;
         }

--- a/test/Sniffs/PHP/ImportInternalConstantUnitTest.inc
+++ b/test/Sniffs/PHP/ImportInternalConstantUnitTest.inc
@@ -24,3 +24,10 @@ define('MY_CONST', 'value');
 $myConst = MY_CONST;
 
 $c = \T_VAR;
+
+class A
+{
+    const TRUE = true;
+
+    const SORT_ASC = SORT_ASC;
+}

--- a/test/Sniffs/PHP/ImportInternalConstantUnitTest.inc.fixed
+++ b/test/Sniffs/PHP/ImportInternalConstantUnitTest.inc.fixed
@@ -6,6 +6,7 @@ use const E_ALL;
 use const E_NOTICE;
 use const E_WARNING;
 use const SEEK_END;
+use const SORT_ASC;
 use const T_VAR;
 use const T_WHITESPACE;
 
@@ -31,3 +32,10 @@ define('MY_CONST', 'value');
 $myConst = MY_CONST;
 
 $c = T_VAR;
+
+class A
+{
+    const TRUE = true;
+
+    const SORT_ASC = SORT_ASC;
+}

--- a/test/Sniffs/PHP/ImportInternalConstantUnitTest.php
+++ b/test/Sniffs/PHP/ImportInternalConstantUnitTest.php
@@ -62,6 +62,7 @@ class ImportInternalConstantUnitTest extends AbstractTestCase
             8 => 2,
             21 => 1,
             26 => 1,
+            32 => 1,
         ];
     }
 


### PR DESCRIPTION
If the previous token is `const` it's a constant declaration and not a usage of a PHP constant.

I'm not 100% sure if thats the right way to do it because it's first time I've looked into sniffs. Also, no idea how to write a test for that 🙂 

fixes #120

Edit: If it's not correct, just close the PR
Edit2: If you're fine with it, I'd be very thankful if you add the hacktoberfest label to it 🙃 