### PR TITLE
Fixes crash on NamingConventions\Exception sniff when parent class does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#133](https://github.com/webimpress/coding-standard/pull/133) fixes crashing when parent class does not exist in `NamingConventions\Exception` sniff.
 
 ## 1.1.7 - 2020-11-27
 

--- a/src/WebimpressCodingStandard/Sniffs/NamingConventions/ExceptionSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/NamingConventions/ExceptionSniff.php
@@ -52,7 +52,12 @@ class ExceptionSniff implements Sniff
 
         $fqn = $this->getNamespace($phpcsFile, $stackPtr) . '\\' . $string;
 
-        if (! class_exists($fqn)) {
+        try {
+            if (! class_exists($fqn)) {
+                return;
+            }
+        } catch (Throwable $e) {
+            // Unable to load class for some reason - non existing parent class?
             return;
         }
 

--- a/test/Integration/ExceptionWithNonExistingParent.php
+++ b/test/Integration/ExceptionWithNonExistingParent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace WebimpressCodingStandardTest\Integration;
+
+class ExceptionWithNonExistingParent extends NonExistingParent
+{
+}

--- a/test/Integration/ExceptionWithNonExistingParent.php.fixed
+++ b/test/Integration/ExceptionWithNonExistingParent.php.fixed
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebimpressCodingStandardTest\Integration;
+
+class ExceptionWithNonExistingParent extends NonExistingParent
+{
+}


### PR DESCRIPTION
Fixes #128