### PR TITLE
Fixes for PHP 8 match expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#143](https://github.com/webimpress/coding-standard/pull/143) fixes support for [PHP 8 `match`](https://www.php.net/match) expression.
 
 ## 1.2.1 - 2021-01-11
 

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "squizlabs/php_codesniffer": "^3.5.8"
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4.3"
+        "phpunit/phpunit": "^9.5.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f72552f05dcdf7b34d35d2bbfce009a",
+    "content-hash": "b6c0cb7e8be6393ac1818c8ba4ce2664",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -55,7 +55,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         }
     ],
     "packages-dev": [
@@ -180,16 +180,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.3",
+            "version": "v4.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984"
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
-                "reference": "dbe56d23de8fcb157bbc0cfb3ad7c7de0cfb0984",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
                 "shasum": ""
             },
             "require": {
@@ -228,7 +228,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-12-03T17:45:45+00:00"
+            "time": "2020-12-20T10:01:03+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -288,16 +288,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.3",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/726c026815142e4f8677b7cb7f2249c9ffb7ecae",
-                "reference": "726c026815142e4f8677b7cb7f2249c9ffb7ecae",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -331,7 +331,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2020-11-30T09:21:21+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -481,16 +481,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -502,7 +502,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -540,20 +540,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-09-29T09:10:42+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "version": "9.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
                 "shasum": ""
             },
             "require": {
@@ -613,7 +613,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2021-03-28T07:26:59+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -842,16 +842,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.0",
+            "version": "9.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe"
+                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
-                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c73c6737305e779771147af66c96ca6a7ed8a741",
+                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741",
                 "shasum": ""
             },
             "require": {
@@ -937,7 +937,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-04T05:05:53+00:00"
+            "time": "2021-03-23T07:16:29+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1841,16 +1841,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
@@ -1862,7 +1862,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1913,7 +1913,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1963,30 +1963,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2008,7 +2013,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],

--- a/src/WebimpressCodingStandard/Sniffs/ControlStructures/DefaultAsLastSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/ControlStructures/DefaultAsLastSniff.php
@@ -31,6 +31,12 @@ class DefaultAsLastSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
         $default = $tokens[$stackPtr];
         $switchPtr = key(array_reverse($default['conditions'], true));
+
+        // skip in case of default statement in PHP 8 match expression
+        if ($switchPtr === null) {
+            return;
+        }
+
         $closer = $tokens[$switchPtr]['scope_closer'];
 
         $from = $stackPtr;

--- a/src/WebimpressCodingStandard/Sniffs/ControlStructures/RedundantCaseSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/ControlStructures/RedundantCaseSniff.php
@@ -41,6 +41,14 @@ class RedundantCaseSniff implements Sniff
     {
         $tokens = $phpcsFile->getTokens();
 
+        $default = $tokens[$stackPtr];
+        $switchPtr = key(array_reverse($default['conditions'], true));
+
+        // in case of PHP 8 match expression
+        if ($switchPtr === null) {
+            return $stackPtr + 1;
+        }
+
         if ($tokens[$stackPtr]['code'] === T_CASE) {
             $next = $stackPtr;
 

--- a/src/WebimpressCodingStandard/Sniffs/Formatting/RedundantParenthesesSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Formatting/RedundantParenthesesSniff.php
@@ -38,6 +38,7 @@ use const T_INLINE_THEN;
 use const T_INSTANCEOF;
 use const T_ISSET;
 use const T_LIST;
+use const T_MATCH;
 use const T_OBJECT_OPERATOR;
 use const T_OPEN_PARENTHESIS;
 use const T_OPEN_TAG;
@@ -69,6 +70,7 @@ class RedundantParenthesesSniff implements Sniff
         T_ISSET,
         T_LIST,
         T_SELF,
+        T_MATCH,
         T_STATIC,
         T_STRING,
         T_UNSET,

--- a/src/WebimpressCodingStandard/Sniffs/PHP/RedundantSemicolonSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/PHP/RedundantSemicolonSniff.php
@@ -17,6 +17,7 @@ use const T_CLOSURE;
 use const T_COLON;
 use const T_FOR;
 use const T_GOTO_LABEL;
+use const T_MATCH;
 use const T_OPEN_CURLY_BRACKET;
 use const T_OPEN_TAG;
 use const T_SEMICOLON;
@@ -70,7 +71,7 @@ class RedundantSemicolonSniff implements Sniff
         }
 
         $scopeCondition = $tokens[$prev]['scope_condition'];
-        if (in_array($tokens[$scopeCondition]['code'], [T_ANON_CLASS, T_CLOSURE], true)) {
+        if (in_array($tokens[$scopeCondition]['code'], [T_ANON_CLASS, T_CLOSURE, T_MATCH], true)) {
             return;
         }
 

--- a/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.inc
+++ b/test/Sniffs/ControlStructures/DefaultAsLastUnitTest.inc
@@ -18,3 +18,8 @@ switch (true) {
     case 4:
         break;
 }
+
+match ($x) {
+    default => 0,
+    1 => 2,
+};

--- a/test/Sniffs/ControlStructures/RedundantCaseUnitTest.inc
+++ b/test/Sniffs/ControlStructures/RedundantCaseUnitTest.inc
@@ -181,3 +181,8 @@ switch (true) {
         echo 'default';
         break;
 }
+
+match ($x) {
+    default => 3,
+    1 => 2,
+};

--- a/test/Sniffs/ControlStructures/RedundantCaseUnitTest.inc.fixed
+++ b/test/Sniffs/ControlStructures/RedundantCaseUnitTest.inc.fixed
@@ -138,3 +138,8 @@ switch (true) {
         echo 'default';
         break;
 }
+
+match ($x) {
+    default => 3,
+    1 => 2,
+};

--- a/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc
+++ b/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc
@@ -199,4 +199,12 @@ class RedundantParentheses
             ? $a->bar()
             : ($a->baz() instanceof \DateTime ? 1 : 2);
     }
+
+    public function php8match($x)
+    {
+        return match ($x) {
+            1 => 2,
+            default => 0,
+        };
+    }
 }

--- a/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc.fixed
+++ b/test/Sniffs/Formatting/RedundantParenthesesUnitTest.inc.fixed
@@ -199,4 +199,12 @@ class RedundantParentheses
             ? $a->bar()
             : ($a->baz() instanceof \DateTime ? 1 : 2);
     }
+
+    public function php8match($x)
+    {
+        return match ($x) {
+            1 => 2,
+            default => 0,
+        };
+    }
 }

--- a/test/Sniffs/PHP/RedundantSemicolonUnitTest.inc
+++ b/test/Sniffs/PHP/RedundantSemicolonUnitTest.inc
@@ -35,3 +35,8 @@ switch (true) {
 }
 
 label:;
+
+match (true) {
+    1 => 2,
+    default => 0,
+};

--- a/test/Sniffs/PHP/RedundantSemicolonUnitTest.inc.fixed
+++ b/test/Sniffs/PHP/RedundantSemicolonUnitTest.inc.fixed
@@ -35,3 +35,8 @@ switch (true) {
 }
 
 label:
+
+match (true) {
+    1 => 2,
+    default => 0,
+};


### PR DESCRIPTION
- ControlStructures\DefaultAsLastSniff
- ControlStructures\RedundantCaseSniff
- Formatting\RedundantParenthesesSniff
- PHP\RedundantSemicolonSniff

Requires PHP_CodeSniffer release to get it working on pre PHP 8.