### PR TITLE
fix: Union return type (PHP 8.2) - Functions\ReturnTypeSniff

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/Functions/ReturnTypeSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Functions/ReturnTypeSniff.php
@@ -25,6 +25,7 @@ use function in_array;
 use function ltrim;
 use function preg_grep;
 use function preg_replace;
+use function preg_match;
 use function preg_split;
 use function sprintf;
 use function str_replace;
@@ -974,7 +975,7 @@ class ReturnTypeSniff implements Sniff
                 return 'new';
 
             case T_NULL:
-                if (!$this->hasCorrectTypeRegExp(['/null/', '/mixed/', '/\?\w+/i'])) {
+                if (! $this->hasCorrectTypeRegExp(['/null/', '/mixed/', '/\?\w+/i'])) {
                     $error = 'Function return type is not nullable, but function returns null here';
                     $phpcsFile->addError($error, $ptr, 'ReturnNull');
                 }

--- a/src/WebimpressCodingStandard/Sniffs/Functions/ReturnTypeSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Functions/ReturnTypeSniff.php
@@ -934,14 +934,14 @@ class ReturnTypeSniff implements Sniff
                 return 'bool';
 
             case T_FALSE:
-                if (! $this->hasCorrectType(['bool', '?bool'], ['bool', 'boolean', 'false', 'mixed'])) {
+                if (! $this->hasCorrectTypeRegExp(['/bool/', '/boolean/', '/false/', '/mixed/'])) {
                     $error = 'Function return type is not bool, but function returns boolean false here';
                     $phpcsFile->addError($error, $ptr, 'ReturnFalse');
                 }
                 return 'false';
 
             case T_TRUE:
-                if (! $this->hasCorrectType(['bool', '?bool'], ['bool', 'boolean', 'true', 'mixed'])) {
+                if (! $this->hasCorrectTypeRegExp(['/bool/', '/boolean/', '/true/', '/mixed/'])) {
                     $error = 'Function return type is not bool, but function returns boolean true here';
                     $phpcsFile->addError($error, $ptr, 'ReturnTrue');
                 }
@@ -974,11 +974,7 @@ class ReturnTypeSniff implements Sniff
                 return 'new';
 
             case T_NULL:
-                if (! $this->hasCorrectType([], ['null'])
-                    || ($this->returnType
-                        && $this->returnTypeIsValid
-                        && strpos($this->returnTypeValue, '?') !== 0)
-                ) {
+                if (!$this->hasCorrectTypeRegExp(['/null/', '/mixed/', '/\?\w+/i'])) {
                     $error = 'Function return type is not nullable, but function returns null here';
                     $phpcsFile->addError($error, $ptr, 'ReturnNull');
                 }
@@ -998,6 +994,23 @@ class ReturnTypeSniff implements Sniff
         }
 
         return 'unknown';
+    }
+
+    /**
+     * @param string[] $expectedType
+     */
+    private function hasCorrectTypeRegExp(array $expectedType) : bool
+    {
+        foreach ($expectedType as $value) {
+            if ($this->returnType && $this->returnTypeIsValid && preg_match($value, $this->returnTypeValue)) {
+                return true;
+            }
+            if ($this->returnDoc && $this->returnDocIsValid && preg_match($value, $this->returnDocValue)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/test/Sniffs/Functions/ReturnTypeUnitTest.inc
+++ b/test/Sniffs/Functions/ReturnTypeUnitTest.inc
@@ -397,4 +397,13 @@ abstract class FunctionCommentReturn
 
         return $a;
     }
+
+    public function insert(array $data): bool|mysqli_result
+    {
+        if (empty($data)) {
+            return false;
+        }
+
+        return new mysqli_result;
+    }
 }


### PR DESCRIPTION
Case like 
```
    public function insert(array $data): bool|mysqli_result
    {
        if (empty($data)) {
            return false;
        }
        return new mysqli_result;
    }
```