### PR TITLE
feat: Support union and intersection return types - Formatting\ReturnTypeSniff

### DIFF
--- a/test/Sniffs/Formatting/ReturnTypeUnitTest.inc
+++ b/test/Sniffs/Formatting/ReturnTypeUnitTest.inc
@@ -98,3 +98,12 @@ class NonFixable
 }
 
 static fn (string $a):int => $a;
+
+abstract class PHP82 {
+    abstract public function union(): Bool|String;
+    abstract public function intersection(): Iterator&Countable;
+    abstract public function boolFalse(): False;
+    abstract public function boolTrue(): TRUE;
+    abstract public function null(): NULL;
+    abstract public function parenthesis(): (Iterator&Countable)|Object;
+}

--- a/test/Sniffs/Formatting/ReturnTypeUnitTest.inc.fixed
+++ b/test/Sniffs/Formatting/ReturnTypeUnitTest.inc.fixed
@@ -96,3 +96,12 @@ class NonFixable
 }
 
 static fn (string $a): int => $a;
+
+abstract class PHP82 {
+    abstract public function union(): bool|string;
+    abstract public function intersection(): Iterator&Countable;
+    abstract public function boolFalse(): false;
+    abstract public function boolTrue(): true;
+    abstract public function null(): null;
+    abstract public function parenthesis(): (Iterator&Countable)|object;
+}

--- a/test/Sniffs/Formatting/ReturnTypeUnitTest.php
+++ b/test/Sniffs/Formatting/ReturnTypeUnitTest.php
@@ -60,6 +60,11 @@ class ReturnTypeUnitTest extends AbstractTestCase
             93 => 1,
             95 => 1,
             100 => 1,
+            103 => 2,
+            105 => 1,
+            106 => 1,
+            107 => 1,
+            108 => 1,
         ];
     }
 


### PR DESCRIPTION
Allow the following Return types:

```php

function union(): bool|string;

function intersection(): Iterator&Countable;

function nullType(): null;

function boolFalse(): false;

function boolTrue(): true;

function unionAndIntersection(): string|(Iterator&Countable);
```