### PR TITLE
fix: WhiteSpace\OperatorAndKeywordSpacingSniff - conflict with declare statement since PHP_CodeSniffer 3.9.1

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/WhiteSpace/OperatorAndKeywordSpacingSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/WhiteSpace/OperatorAndKeywordSpacingSniff.php
@@ -40,15 +40,29 @@ class OperatorAndKeywordSpacingSniff extends OperatorSpacingSniff
         $tokens[] = T_INSTEADOF;
         $tokens[] = T_FN_ARROW;
 
+        // Also register the contexts we want to specifically skip over.
+        $tokens[] = T_DECLARE;
+
         return $tokens;
     }
 
     /**
      * @param int $stackPtr
      */
-    public function process(File $phpcsFile, $stackPtr) : void
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
+
+        // Skip over declare statements as those should be handled by different sniffs.
+        if ($tokens[$stackPtr]['code'] === T_DECLARE) {
+            if (isset($tokens[$stackPtr]['parenthesis_closer']) === false) {
+                // Parse error / live coding.
+                return $phpcsFile->numTokens;
+            }
+
+            return $tokens[$stackPtr]['parenthesis_closer'];
+        }
+
 
         $originalValue = $this->ignoreNewlines;
         if (in_array($tokens[$stackPtr]['code'], $this->doNotIgnoreNewLineForTokens, true)) {

--- a/src/WebimpressCodingStandard/Sniffs/WhiteSpace/OperatorAndKeywordSpacingSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/WhiteSpace/OperatorAndKeywordSpacingSniff.php
@@ -11,6 +11,7 @@ use PHP_CodeSniffer\Util\Tokens;
 use function in_array;
 
 use const T_AS;
+use const T_DECLARE;
 use const T_FN_ARROW;
 use const T_INSTANCEOF;
 use const T_INSTEADOF;
@@ -48,6 +49,7 @@ class OperatorAndKeywordSpacingSniff extends OperatorSpacingSniff
 
     /**
      * @param int $stackPtr
+     * @return null|int
      */
     public function process(File $phpcsFile, $stackPtr)
     {
@@ -62,7 +64,6 @@ class OperatorAndKeywordSpacingSniff extends OperatorSpacingSniff
 
             return $tokens[$stackPtr]['parenthesis_closer'];
         }
-
 
         $originalValue = $this->ignoreNewlines;
         if (in_array($tokens[$stackPtr]['code'], $this->doNotIgnoreNewLineForTokens, true)) {

--- a/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.1.inc
+++ b/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.1.inc
@@ -1,0 +1,3 @@
+<?php
+// Safeguard to ensure that sniff handles parse error/live coding correctly.
+declare(strict_types=

--- a/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc
+++ b/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $c
 =
     $a

--- a/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc.fixed
+++ b/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.inc.fixed
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $c
     = $a
     + $b;

--- a/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.php
+++ b/test/Sniffs/WhiteSpace/OperatorAndKeywordSpacingUnitTest.php
@@ -10,18 +10,22 @@ class OperatorAndKeywordSpacingUnitTest extends AbstractTestCase
 {
     protected function getErrorList(string $testFile = '') : array
     {
+        if ($testFile === 'OperatorAndKeywordSpacingUnitTest.1.inc') {
+            return [];
+        }
+
         return [
-            4 => 1,
             6 => 1,
-            11 => 2,
-            12 => 2,
-            17 => 2,
-            21 => 1,
+            8 => 1,
+            13 => 2,
+            14 => 2,
+            19 => 2,
             23 => 1,
-            27 => 1,
-            31 => 1,
-            35 => 1,
-            39 => 2,
+            25 => 1,
+            29 => 1,
+            33 => 1,
+            37 => 1,
+            41 => 2,
         ];
     }
 


### PR DESCRIPTION
PR https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/289 changes a lot around operator sniff, and now declare statement must be omitted (as it was done also for PSR-12 rule there). There is another sniff to verify declare statement, and we do not want to check it here.