### PR TITLE
fix: Formatting\ReturnTypeSniff to use new type of token for parenthesis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "squizlabs/php_codesniffer": "^3.7.2"
+        "squizlabs/php_codesniffer": "^3.10.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.15"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b680160d9103548d71bd9e20ca49fe72",
+    "content-hash": "072bfe94487842ec5f19f56f532ac9a3",
     "packages": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.10.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
+                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
                 "shasum": ""
             },
             "require": {
@@ -27,11 +27,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -46,17 +46,45 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
-            "time": "2023-02-22T23:07:41+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-09-18T10:38:58+00:00"
         }
     ],
     "packages-dev": [
@@ -1681,12 +1709,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.3 || ^8.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/WebimpressCodingStandard/Sniffs/Formatting/ReturnTypeSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/Formatting/ReturnTypeSniff.php
@@ -26,13 +26,14 @@ use const T_NS_SEPARATOR;
 use const T_NULL;
 use const T_NULLABLE;
 use const T_OPEN_CURLY_BRACKET;
-use const T_OPEN_PARENTHESIS;
 use const T_PARENT;
 use const T_SELF;
 use const T_SEMICOLON;
 use const T_STRING;
 use const T_TRUE;
+use const T_TYPE_CLOSE_PARENTHESIS;
 use const T_TYPE_INTERSECTION;
+use const T_TYPE_OPEN_PARENTHESIS;
 use const T_TYPE_UNION;
 use const T_USE;
 use const T_WHITESPACE;
@@ -116,8 +117,8 @@ class ReturnTypeSniff implements Sniff
                 T_TYPE_UNION,
                 T_PARENT,
                 T_WHITESPACE,
-                T_OPEN_PARENTHESIS,
-                T_CLOSE_PARENTHESIS,
+                T_TYPE_OPEN_PARENTHESIS,
+                T_TYPE_CLOSE_PARENTHESIS,
             ],
             $parenthesisCloser + 1,
             $eol,
@@ -150,8 +151,8 @@ class ReturnTypeSniff implements Sniff
         }
 
         $notTypes = [
-            T_OPEN_PARENTHESIS,
-            T_CLOSE_PARENTHESIS,
+            T_TYPE_OPEN_PARENTHESIS,
+            T_TYPE_CLOSE_PARENTHESIS,
             T_BITWISE_AND,
             T_BITWISE_OR,
             T_TYPE_INTERSECTION,


### PR DESCRIPTION
Since [PHP_CodeSniffer 3.10.0](https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.10.0) parenthesis token has been changed to:
- `T_TYPE_OPEN_PARENTHESIS` (from `T_OPEN_PARENTHESIS`)
- `T_TYPE_CLOSE_PARENTHESIS` (from `T_CLOSE_PARENTHESIS`)

and therefore the sniff did not work correctly for composite return type declarations.

Bump minimum PHP_CodeSniffer version to 3.10.3 so the new tokens are defined.