### PR TITLE
qa: Remove redundant code in WhiteSpace\ScopeIndentSniff as upstream is fixed

### DIFF
--- a/src/WebimpressCodingStandard/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/src/WebimpressCodingStandard/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -572,7 +572,7 @@ class ScopeIndentSniff implements Sniff
                 if ($tokens[$prev]['line'] === $tokens[$i]['line']
                     && ! ($fp = $this->findPrevious($phpcsFile, $i, [T_OBJECT_OPERATOR]))
                 ) {
-                    $endOfStatement = min($this->findEndOfStatement($phpcsFile, $i), $this->findNext($phpcsFile, $i));
+                    $endOfStatement = min($phpcsFile->findEndOfStatement($i), $this->findNext($phpcsFile, $i));
                     $newLine = $this->hasContainNewLine($phpcsFile, $i, $endOfStatement);
 
                     if ($newLine) {
@@ -618,7 +618,7 @@ class ScopeIndentSniff implements Sniff
                 ],
                 true
             )) {
-                $endOfStatement = $this->findEndOfStatement($phpcsFile, $i);
+                $endOfStatement = $phpcsFile->findEndOfStatement($i);
                 $newLine = $this->hasContainNewLine($phpcsFile, $i, $endOfStatement);
 
                 if ($newLine) {
@@ -640,7 +640,7 @@ class ScopeIndentSniff implements Sniff
                     && isset($tokens[$next]['scope_closer'])
                     && $tokens[$next]['scope_closer'] === $next
                 ) {
-                    $endOfStatement = $this->findEndOfStatement($phpcsFile, $next);
+                    $endOfStatement = $phpcsFile->findEndOfStatement($next);
                     $this->extras($endOfStatement, $this->indent);
 
                     $extraIndent += $this->indent;
@@ -944,70 +944,6 @@ class ScopeIndentSniff implements Sniff
         }
 
         return null;
-    }
-
-    /**
-     * Overrides File::findEndOfStatement as temporary solution until
-     * https://github.com/squizlabs/PHP_CodeSniffer/issues/2748
-     * is fixed.
-     */
-    private function findEndOfStatement(File $phpcsFile, int $ptr) : int
-    {
-        $closingBracket = [
-            T_CLOSE_PARENTHESIS,
-            T_CLOSE_SQUARE_BRACKET,
-            T_CLOSE_CURLY_BRACKET,
-            T_CLOSE_SHORT_ARRAY,
-        ];
-
-        $tokens = $phpcsFile->getTokens();
-        $lastToken = $phpcsFile->numTokens;
-
-        if ($tokens[$ptr]['code'] === T_DOUBLE_ARROW && $ptr < $lastToken) {
-            ++$ptr;
-        }
-
-        while ($ptr < $lastToken) {
-            if ($tokens[$ptr]['code'] === T_OPEN_PARENTHESIS) {
-                $ptr = $tokens[$ptr]['parenthesis_closer'] + 1;
-                continue;
-            }
-
-            if ($tokens[$ptr]['code'] === T_OPEN_CURLY_BRACKET
-                || $tokens[$ptr]['code'] === T_OPEN_SQUARE_BRACKET
-                || $tokens[$ptr]['code'] === T_OPEN_SHORT_ARRAY
-            ) {
-                $ptr = $tokens[$ptr]['bracket_closer'] + 1;
-                continue;
-            }
-
-            if (isset($tokens[$ptr]['scope_closer']) && $ptr < $tokens[$ptr]['scope_closer']) {
-                $ptr = $tokens[$ptr]['scope_closer'];
-                if (in_array($tokens[$ptr]['code'], $closingBracket, true)) {
-                    ++$ptr;
-                }
-            } elseif (isset($tokens[$ptr]['parenthesis_closer']) && $ptr < $tokens[$ptr]['parenthesis_closer']) {
-                $ptr = $tokens[$ptr]['parenthesis_closer'];
-                if (in_array($tokens[$ptr]['code'], $closingBracket, true)) {
-                    ++$ptr;
-                }
-            }
-
-            if ($tokens[$ptr]['code'] === T_COMMA
-                || $tokens[$ptr]['code'] === T_SEMICOLON
-                || $tokens[$ptr]['code'] === T_DOUBLE_ARROW
-            ) {
-                return $ptr;
-            }
-
-            if (in_array($tokens[$ptr]['code'], $closingBracket, true)) {
-                return $phpcsFile->findPrevious(Tokens::$emptyTokens, $ptr - 1, null, true);
-            }
-
-            ++$ptr;
-        }
-
-        return $lastToken;
     }
 
     /**


### PR DESCRIPTION


Related issue https://github.com/squizlabs/PHP_CodeSniffer/issues/2748 has been merged and deployed, and we are now using version where the fix is present, so there is no longer need for the custom code, and it is removed now.